### PR TITLE
feat: migrate podcast endpoints from iTunes to Spotify API

### DIFF
--- a/app/api/jobs/subscription/searchkeyword/update/route.ts
+++ b/app/api/jobs/subscription/searchkeyword/update/route.ts
@@ -1,6 +1,7 @@
 import { generateFeedItemId } from "@/libs/common";
-import { searchPodcastEpisodeFromItunes } from "@/libs/itunes";
+// import { searchPodcastEpisodeFromItunes } from "@/libs/itunes";
 import prisma from "@/libs/prisma";
+import { searchSpotifyEpisodes } from "@/libs/spotify";
 import { FeedItem } from "@/types/feed_item";
 import { Prisma } from "@prisma/client";
 import { NextRequest } from "next/server";
@@ -88,7 +89,8 @@ export async function POST(request: NextRequest) {
         })
     }
 
-    const feedItemList = await searchPodcastEpisodeFromItunes(keyword, 'podcastEpisode', country, excludeFeedIds, 0, 0, 200)
+    // const feedItemList = await searchPodcastEpisodeFromItunes(keyword, 'podcastEpisode', country, excludeFeedIds, 0, 0, 200)
+    const feedItemList = await searchSpotifyEpisodes(keyword, country, 50, 0)
 
     if (!feedItemList || feedItemList.length === 0) {
         resp.code = 1

--- a/app/api/listenlater/item/route.ts
+++ b/app/api/listenlater/item/route.ts
@@ -2,6 +2,7 @@ import { generateFeedItemId, generateID } from "@/libs/common";
 import { createOrUpdateFeedItem } from "@/libs/db/feed_item";
 import { getPodcastEpisodeInfo } from "@/libs/itunes";
 import prisma from "@/libs/prisma";
+import { getSpotifyEpisodeDetail } from "@/libs/spotify";
 import { FeedItem } from "@/types/feed_item";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -18,7 +19,8 @@ export async function POST(request: NextRequest) {
     const userId = body.userId
     const channelId = body.channelId
     const itemId = body.itemId
-    const source = body.source || 'itunes'
+    // const source = body.source || 'itunes'
+    const source = body.source || 'spotify'
     if (!userId || !channelId || !itemId) {
         resp.code = 1
         resp.message = 'Missing required fields'
@@ -26,8 +28,12 @@ export async function POST(request: NextRequest) {
     }
 
     let itemInfoResp;
+    let feedItem: FeedItem
     if (source == 'itunes') {
         itemInfoResp = await getPodcastEpisodeInfo(channelId, itemId)
+        feedItem = itemInfoResp.episode
+    } else {
+        feedItem = await getSpotifyEpisodeDetail(itemId)
     }
 
     if (!itemInfoResp) {
@@ -36,7 +42,6 @@ export async function POST(request: NextRequest) {
         return NextResponse.json(resp)
     }
 
-    let feedItem: FeedItem = itemInfoResp.episode
     feedItem.Id = await generateFeedItemId(feedItem.FeedLink, feedItem.Title)
     feedItem.ChannelId = await generateFeedItemId(feedItem.FeedLink, feedItem.ChannelTitle)
 

--- a/app/api/playlist/item/route.ts
+++ b/app/api/playlist/item/route.ts
@@ -2,6 +2,7 @@ import { generateFeedItemId, generatePlaylistItemId } from "@/libs/common";
 import { queryPlaylistByPlaylistId } from "@/libs/db/playlist";
 import { getPodcastEpisodeInfo } from "@/libs/itunes";
 import prisma from "@/libs/prisma";
+import { getSpotifyEpisodeDetail } from "@/libs/spotify";
 import { FeedItem } from "@/types/feed_item";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -12,7 +13,8 @@ export async function POST(request: NextRequest) {
     const playlistId = body.playlistId
     const channelId = body.channelId
     const guid = body.guid
-    const source = body.source || 'itunes'
+    // const source = body.source || 'itunes'
+    const source = body.source || 'spotify'
 
     const resp: JsonResponse = {
         code: 0,
@@ -34,8 +36,12 @@ export async function POST(request: NextRequest) {
     }
 
     let itemInfoResp;
+    let feedItem: FeedItem
     if (source == 'itunes') {
         itemInfoResp = await getPodcastEpisodeInfo(channelId, guid)
+        feedItem = itemInfoResp.episode
+    } else {
+        feedItem = await getSpotifyEpisodeDetail(guid)
     }
 
     if (!itemInfoResp) {
@@ -44,7 +50,6 @@ export async function POST(request: NextRequest) {
         return NextResponse.json(resp)
     }
 
-    let feedItem: FeedItem = itemInfoResp.episode
     feedItem.Id = await generateFeedItemId(feedItem.FeedLink, feedItem.Title)
     feedItem.ChannelId = await generateFeedItemId(feedItem.FeedLink, feedItem.ChannelTitle)
 

--- a/app/api/podcast/episode/[itemId]/route.ts
+++ b/app/api/podcast/episode/[itemId]/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { JsonResponse } from "@/types/api";
+import { getSpotifyEpisodeDetail } from "@/libs/spotify";
+
+export async function GET(request: NextRequest, { params }: { params: { itemId: string } }) {
+    try {
+        const { itemId } = params;
+
+        // Get market from query params (optional, default 'US')
+        const searchParams = request.nextUrl.searchParams;
+        const market = searchParams.get('market') || 'US';
+
+        // Get episode detail from Spotify
+        const episodeDetail = await getSpotifyEpisodeDetail(itemId, market);
+
+        const resp: JsonResponse = {
+            code: 0,
+            message: '',
+            data: episodeDetail
+        };
+        return NextResponse.json(resp);
+    } catch (error) {
+        console.error('Error getting podcast episode detail:', error);
+
+        const resp: JsonResponse = {
+            code: 1,
+            message: error instanceof Error ? error.message : 'Unknown error occurred',
+            data: null
+        };
+        return NextResponse.json(resp, { status: 500 });
+    }
+}

--- a/app/api/search/episode/route.ts
+++ b/app/api/search/episode/route.ts
@@ -1,0 +1,19 @@
+import { searchSpotifyEpisodes } from "@/libs/spotify"
+import { NextRequest, NextResponse } from "next/server"
+
+
+export async function GET(request: NextRequest) {
+
+    const searchParams = request.nextUrl.searchParams
+    const q = searchParams.get('q')
+    const country = searchParams.get('country')
+    const offset = Number(searchParams.get('offset')) || 0
+    const limit = Number(searchParams.get('limit')) || 10
+    const data = await searchSpotifyEpisodes(q || '', country || 'US', limit, offset)
+    const resp: JsonResponse = {
+        code: 0,
+        message: '',
+        data: data
+    }
+    return NextResponse.json(resp)
+}

--- a/app/api/subscription/keyword/route.ts
+++ b/app/api/subscription/keyword/route.ts
@@ -12,7 +12,8 @@ export async function POST(request: NextRequest) {
     const userId = reqBody.userId;
     const keyword = reqBody.keyword;
     const country = reqBody.country || 'US';
-    const source = reqBody.source || 'itunes';
+    // const source = reqBody.source || 'itunes';
+    const source = reqBody.source || 'spotify';
     const excludeFeedId = reqBody.excludeFeedId || '';
     const sortByDate = reqBody.sortByDate;
 

--- a/app/api/subscription/keyword/search/route.tsx
+++ b/app/api/subscription/keyword/search/route.tsx
@@ -7,7 +7,8 @@ export async function POST(request: NextRequest) {
     const reqBody = await request.json();
     const keyword = reqBody.keyword;
     const country = reqBody.country || 'US';
-    const source = reqBody.source || 'itunes';
+    // const source = reqBody.source || 'itunes';
+    const source = reqBody.source || 'spotify';
     const excludeFeedId = reqBody.excludeFeedId || '';
     const sortByDate = reqBody.sortByDate;
     let resp: JsonResponse = {

--- a/app/podcast/[channelId]/episode/[itemId]/page.tsx
+++ b/app/podcast/[channelId]/episode/[itemId]/page.tsx
@@ -6,16 +6,19 @@ import { AppProvider } from "@/components/AppContext"
 import AddListenLaterButton from "@/components/AddListenLaterButton"
 import AddToPlaylistButton from "@/components/AddToPlaylistButton"
 import ShowNotesViewer from "@/components/ShowNotesViewer"
-import { getPodcastEpisodeInfo } from "@/libs/itunes"
+// import { getPodcastEpisodeInfo } from "@/libs/itunes"
 import { Author } from "next/dist/lib/metadata/types/metadata-types"
 import { removeTextColorStyles } from "@/libs/common"
+import { getSpotifyEpisodeDetail, getSpotifyShowDetail } from "@/libs/spotify"
 
 
 export default async function Page({ params }: { params: { channelId: string, itemId: string } }) {
 
-    const data = await getPodcastEpisodeInfo(params.channelId, params.itemId)
-    const episode = data.episode
-    const podcastInfo = data.podcast
+    // const data = await getPodcastEpisodeInfo(params.channelId, params.itemId)
+    // const episode = data.episode
+    // const podcastInfo = data.podcast
+    const episode = await getSpotifyEpisodeDetail(params.itemId)
+    const podcastInfo = await getSpotifyShowDetail(params.channelId)
     const podcastChannelLink = "/podcast/" + episode.ChannelId
     const formatDescription = removeTextColorStyles(episode.Description)
 
@@ -92,13 +95,17 @@ export async function generateMetadata(
     { params }: { params: { channelId: string, itemId: string } },
     parent: ResolvingMetadata
 ): Promise<Metadata> {
-    const podcastData = await getPodcastEpisodeInfo(params.channelId, params.itemId)
-    const title = podcastData.episode.Title
-    const description = podcastData.episode.Description
+    // const data = await getPodcastEpisodeInfo(params.channelId, params.itemId)
+    // const episode = data.episode
+    // const podcastInfo = data.podcast
+    const episode = await getSpotifyEpisodeDetail(params.itemId)
+    const podcastInfo = await getSpotifyShowDetail(params.channelId)
+    const title = episode.Title
+    const description = episode.Description
     const authorList: Author[] = []
     authorList.push({
-        name: podcastData.podcast.OwnerName,
-        url: podcastData.podcast.OwnerEmail
+        name: podcastInfo.OwnerName,
+        url: podcastInfo.OwnerEmail
     })
 
     return {

--- a/app/podcast/[channelId]/page.tsx
+++ b/app/podcast/[channelId]/page.tsx
@@ -9,6 +9,7 @@ import { addLinkTagToUrl, removeTextColorStyles, replaceWithBr } from '@/libs/co
 import { getPodcastAllInfo } from '@/libs/itunes';
 import { Author } from 'next/dist/lib/metadata/types/metadata-types';
 import { AvatarImage } from '@/components/PorkastImage';
+import { getSpotifyShowDetail, getSpotifyShowEpisodes } from '@/libs/spotify';
 
 export default async function Page({ params, searchParams }: { params: { channelId: string }, searchParams: { page: string } }) {
     const podcastId = params.channelId;
@@ -18,14 +19,11 @@ export default async function Page({ params, searchParams }: { params: { channel
     }
     const limit = 10
     const offest = (parseInt(page || '1') - 1) * limit
-    var podcastData = await getPodcastAllInfo(podcastId)
-    podcastData.episodes = podcastData.episodes.slice(offest, offest + limit)
-    podcastData.podcast.Items = podcastData.podcast.Items.slice(offest, offest + limit)
+    // var podcastData = await getPodcastAllInfo(podcastId)
+    var channelInfoData = await getSpotifyShowDetail(podcastId)
+    var episodes = await getSpotifyShowEpisodes(podcastId, 'US', limit, offest)
+    channelInfoData.Items = episodes
 
-    if (!podcastData) {
-        return
-    }
-    const channelInfoData = podcastData.podcast
     const episodeTotalCount = channelInfoData.Count
     var channelDescription = channelInfoData.TextChannelDesc
     channelDescription = addLinkTagToUrl(channelDescription)
@@ -124,7 +122,7 @@ export default async function Page({ params, searchParams }: { params: { channel
                                                     channelId: item.ChannelId,
                                                     title: item.HighlightTitle,
                                                     description: item.TextDescription,
-                                                    image: item.ImageUrl == "" ? podcastData.podcast.ImageUrl : item.ImageUrl,
+                                                    image: item.ImageUrl == "" ? channelInfoData.ImageUrl : item.ImageUrl,
                                                     link: item.Link,
                                                     rssLink: item.FeedLink,
                                                     channelName: item.ChannelTitle,

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -13,6 +13,8 @@ import { searchPodcastEpisodeFromItunes } from '@/libs/itunes';
 import Loading from '@/components/Loading';
 import AddExcludeFeedIdDialog, { AddExcludeFeedIdDialogRef } from '@/components/AddExcludeFeedIdDialog';
 import SubscribeKeywrodDialog, { SubscribeKeywrodDialogRef } from '@/components/SubscribeKeywrodDialog';
+import { searchSpotifyEpisodes } from '@/libs/spotify';
+import { searchEpisodes } from '@/libs/common';
 
 enum Page {
     NextPage,
@@ -67,7 +69,9 @@ function Search() {
         const fetchData = (async () => {
             setIsLoading(true)
             const offest = (parseInt(page || '1') - 1) * limit
-            const data = await searchPodcastEpisodeFromItunes(q || '', 'podcastEpisode', country || 'US', excludeFeedId || '', offest, limit, searchTotalCount)
+            // const data = await searchPodcastEpisodeFromItunes(q || '', 'podcastEpisode', country || 'US', excludeFeedId || '', offest, limit, searchTotalCount)
+            const data = await searchEpisodes(q || '', country || 'US', offest, limit)
+            console.log(data)
             setIsLoading(false)
             setSearchResultData(data)
             if (data.length > 0) {

--- a/components/EpisodeCard.tsx
+++ b/components/EpisodeCard.tsx
@@ -5,7 +5,9 @@ import AudioPlayButton from './AudioPlayButton';
 import AddListenLaterButton from './AddListenLaterButton';
 import AddToPlaylistButton from './AddToPlaylistButton';
 import { AvatarImage } from './PorkastImage';
-import { parseHtmlStrinText } from '@/libs/common';
+import { getEpisodeDetail, parseHtmlStrinText } from '@/libs/common';
+import { useEffect, useState } from 'react';
+// import { getPodcastInfo } from '@/libs/itunes';
 
 type ExcludeFunction = (channelTitle: string, feedId: string) => void
 
@@ -34,11 +36,10 @@ export default function EpisodeCard(props: EpisodeCardProps) {
 
     const { data } = props
     const urlEncodeItemId = encodeURIComponent(data.itemId)
-    const podcastEpisodeLink = "/podcast/" + data.channelId + "/episode/" + urlEncodeItemId
-    const podcastChannelLink = "/podcast/" + data.channelId
-    data.title = data.title.replace('highlightPlaceholder', 'className="text-primary"');
-    data.authorName = data.authorName.replace('highlightPlaceholder', 'className="text-primary"');
-    data.channelName = data.channelName.replace('highlightPlaceholder', 'className="text-primary"');
+    const [podcastEpisodeLink, setPodcastEpisodeLink] = useState('')
+    const [podcastChannelLink, setPodcastChannelLink] = useState('')
+    const [authorName, setAuthorName] = useState('')
+    const [channelName, setChannelName] = useState('')
     // data.description = data.description.replace('highlightPlaceholder', 'className="text-primary"');
     data.description = parseHtmlStrinText(data.description)
 
@@ -62,6 +63,17 @@ export default function EpisodeCard(props: EpisodeCardProps) {
         }
     }
 
+    useEffect(() => {
+        const initEpisodeInfo = async () => {
+            const episode = await getEpisodeDetail(data.itemId, 'US')
+            setPodcastEpisodeLink("/podcast/" + episode.ChannelId + "/episode/" + urlEncodeItemId)
+            setPodcastChannelLink("/podcast/" + episode.ChannelId)
+            setAuthorName(episode.Author)
+            setChannelName(episode.ChannelTitle)
+        }
+        initEpisodeInfo()
+    }, [data.itemId]);
+
     return (
         <div className="bg-base-100 shadow-xl rounded-box mb-12 pt-9">
             <div className="ml-6 mr-6">
@@ -73,7 +85,7 @@ export default function EpisodeCard(props: EpisodeCardProps) {
                     </a>
                     <div className="ml-3">
                         <div className='md:flex md:justify-start items-center'>
-                            <a href={podcastChannelLink} className="text-base font-medium mr-2">{parse(data.channelName)}</a>
+                            <a href={podcastChannelLink} className="text-base font-medium mr-2">{parse(channelName)}</a>
                             {
                                 props.data.showExcludeBtn ? (
                                     <button className="btn btn-xs btn-neutral items-center rounded-lg mt-0" onClick={onExcludeModalBtnClick}>Exclude</button>
@@ -87,7 +99,7 @@ export default function EpisodeCard(props: EpisodeCardProps) {
                             data.authorName == "" || data.authorName == "null" ? (
                                 <></>
                             ) : (
-                                <div className="text-sm font-medium text-gray-500 mt-2">By {parse(data.authorName)}</div>
+                                <div className="text-sm font-medium text-gray-500 mt-2">By {parse(authorName)}</div>
                             )
                         }
                         <div className="flex justify-start mt-4">

--- a/components/SubscribeKeywrodDialog.tsx
+++ b/components/SubscribeKeywrodDialog.tsx
@@ -6,6 +6,7 @@ import { Ref, forwardRef, useEffect, useState } from "react"
 import { useAppContext } from "./AppContext"
 import { MsgAlertType } from "./MsgAlert"
 import { FeedChannel } from "@/types/feed_channel"
+import { getSpotifyShowDetail } from "@/libs/spotify"
 
 
 export type SubscribeKeywrodDialogRef = {
@@ -53,7 +54,8 @@ const SubscribeKeywrodDialog = forwardRef<SubscribeKeywrodDialogRef>((props, ref
             setIsLoadingExcludeChannelInfo(true)
         }
 
-        const promiseList = feedIdList.map(feedId => getPodcastInfo(feedId))
+        // const promiseList = feedIdList.map(feedId => getPodcastInfo(feedId))
+        const promiseList = feedIdList.map(feedId => getSpotifyShowDetail(feedId))
 
         let channelInfoList: FeedChannel[] = []
         try {

--- a/libs/common.ts
+++ b/libs/common.ts
@@ -1,5 +1,7 @@
 import { v5 as uuidv5 } from 'uuid';
 import { v4 as uuidv4 } from 'uuid';
+import { JsonResponse } from '@/types/api';
+import { FeedItem } from '@/types/feed_item';
 
 
 export const replaceWithBr = (text: string): string => {
@@ -62,4 +64,83 @@ export const generatePlaylistId = async (name: string, userId: string): Promise<
 export const generatePlaylistItemId = async (playlistId: string, itemId: string): Promise<string> => {
     const uniqueId = uuidv5(playlistId + itemId, uuidv5.DNS);
     return uniqueId
+}
+
+/**
+ * Search for podcast episodes using the internal API
+ * @param q Search query string
+ * @param country Country code (default: 'US')
+ * @param offset Pagination offset (default: 0)
+ * @param limit Maximum number of results (default: 10)
+ * @returns Promise<FeedItem[]> Array of podcast episodes
+ */
+export const searchEpisodes = async (q: string, country: string = 'US', offset: number = 0, limit: number = 10
+): Promise<FeedItem[]> => {
+    try {
+        const params = new URLSearchParams({
+            q,
+            country,
+            offset: offset.toString(),
+            limit: limit.toString(),
+        });
+
+        const response = await fetch(`/api/search/episode?${params.toString()}`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const jsonResponse: JsonResponse = await response.json();
+
+        if (jsonResponse.code !== 0) {
+            throw new Error(`API error: ${jsonResponse.message || 'Unknown error'}`);
+        }
+
+        return jsonResponse.data as FeedItem[];
+    } catch (error) {
+        console.error('Error searching episodes:', error);
+        throw error;
+    }
+}
+
+/**
+ * Get detailed information for a specific podcast episode using the internal API
+ * @param episodeId Spotify episode ID
+ * @param market Market code (default: 'US')
+ * @returns Promise<FeedItem> Detailed episode information
+ */
+export const getEpisodeDetail = async (episodeId: string, market: string = 'US'
+): Promise<FeedItem> => {
+    try {
+        const params = new URLSearchParams({
+            market,
+        });
+
+        const response = await fetch(`/api/podcast/episode/${episodeId}?${params.toString()}`, {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            throw new Error(`HTTP error! status: ${response.status}`);
+        }
+
+        const jsonResponse: JsonResponse = await response.json();
+
+        if (jsonResponse.code !== 0) {
+            throw new Error(`API error: ${jsonResponse.message || 'Unknown error'}`);
+        }
+
+        return jsonResponse.data as FeedItem;
+    } catch (error) {
+        console.error('Error getting episode detail:', error);
+        throw error;
+    }
 }

--- a/libs/db/subscription.ts
+++ b/libs/db/subscription.ts
@@ -4,6 +4,7 @@ import { FeedItem, FeedItemDto } from "@/types/feed_item"
 import { Prisma } from "@prisma/client"
 import { formatDateTime, generateFeedItemId } from "../common"
 import { searchPodcastEpisodeFromItunes } from "../itunes"
+import { searchSpotifyEpisodes } from "@/libs/spotify"
 
 
 export async function queryUserKeywordSubscriptionDetail(userId: string, keyword: string): Promise<SubscriptionDataDto> {
@@ -225,7 +226,8 @@ export async function doSearchSubscription(keyword: string, country: string, sou
         const searchResult = await searchPodcastEpisodeFromItunes(keyword, 'podcastEpisode', country, excludeFeedId, 0, 0, 200)
         searchResultItemList.push(...searchResult);
     } else {
-        // TODO: implement other sources
+        const searchResult = await searchSpotifyEpisodes(keyword, country, 50, 0)
+        searchResultItemList.push(...searchResult);
     }
 
     let ksManyInput: Prisma.keyword_subscriptionCreateManyInput[] = [];

--- a/libs/logger.ts
+++ b/libs/logger.ts
@@ -1,0 +1,23 @@
+// Logger utility with environment-based logging levels
+
+const isProduction = process.env.NODE_ENV === 'production';
+
+export const logger = {
+    debug: (message: string, ...args: any[]) => {
+        if (!isProduction) {
+            console.debug(`[DEBUG] ${message}`, ...args);
+        }
+    },
+
+    info: (message: string, ...args: any[]) => {
+        console.info(`[INFO] ${message}`, ...args);
+    },
+
+    warn: (message: string, ...args: any[]) => {
+        console.warn(`[WARN] ${message}`, ...args);
+    },
+
+    error: (message: string, ...args: any[]) => {
+        console.error(`[ERROR] ${message}`, ...args);
+    }
+};

--- a/libs/spotify.ts
+++ b/libs/spotify.ts
@@ -1,0 +1,705 @@
+import { FeedItem } from '@/types/feed_item';
+import { logger } from './logger';
+import { FeedChannel } from '@/types/feed_channel';
+
+interface SpotifyTokenResponse {
+    access_token: string;
+    token_type: string;
+    expires_in: number;
+}
+
+interface TokenCache {
+    token: string;
+    expiresAt: number; // Unix timestamp in milliseconds
+}
+
+// Module-level cache for access token
+let tokenCache: TokenCache | null = null;
+let isFetchingToken = false; // Prevent concurrent token requests
+
+interface SpotifyImage {
+    height: number;
+    url: string;
+    width: number;
+}
+
+interface SpotifyShow {
+    id: string;
+    name: string;
+    description: string;
+    html_description: string;
+    publisher: string;
+    images: SpotifyImage[];
+    external_urls: { spotify: string };
+    total_episodes: number;
+    available_markets: string[];
+    copyrights: Array<{ text: string; type: string }>;
+    languages: string[];
+    explicit: boolean;
+    type: string;
+    uri: string;
+}
+
+interface SpotifyEpisode {
+    id: string;
+    name: string;
+    description: string;
+    html_description: string;
+    duration_ms: number;
+    explicit: boolean;
+    release_date: string;
+    release_date_precision: string;
+    language: string;
+    languages: string[];
+    images: SpotifyImage[];
+    external_urls: { spotify: string };
+    audio_preview_url: string;
+    is_playable: boolean;
+    is_externally_hosted: boolean;
+    type: string;
+    uri: string;
+}
+
+interface SpotifyEpisodeDetail extends SpotifyEpisode {
+    show: SpotifyShow;
+    resume_point?: {
+        fully_played: boolean;
+        resume_position_ms: number;
+    };
+    restrictions?: {
+        reason: string;
+    };
+}
+
+interface SpotifyShowDetail extends SpotifyShow {
+    episodes: {
+        href: string;
+        limit: number;
+        next: string | null;
+        offset: number;
+        previous: string | null;
+        total: number;
+        items: SpotifyEpisode[];
+    };
+}
+
+interface SpotifySearchResponse {
+    episodes: {
+        href: string;
+        limit: number;
+        next: string | null;
+        offset: number;
+        previous: string | null;
+        total: number;
+        items: SpotifyEpisode[];
+    };
+}
+
+export class SpotifyAuthError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'SpotifyAuthError';
+    }
+}
+
+export class SpotifySearchError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'SpotifySearchError';
+    }
+}
+
+export class SpotifyEpisodeDetailError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'SpotifyEpisodeDetailError';
+    }
+}
+
+export class SpotifyShowDetailError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'SpotifyShowDetailError';
+    }
+}
+
+export class SpotifyShowEpisodesError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = 'SpotifyShowEpisodesError';
+    }
+}
+
+/**
+ * Get Spotify access token using client credentials flow with caching
+ * @param clientId Spotify application client ID (optional, uses env var if not provided)
+ * @param clientSecret Spotify application client secret (optional, uses env var if not provided)
+ * @returns Promise<string> Access token
+ */
+export async function getSpotifyAccessToken(clientId?: string, clientSecret?: string): Promise<string> {
+    const now = Date.now();
+    const bufferTime = 5 * 60 * 1000; // 5 minutes buffer before expiration
+
+    // Check if we have a valid cached token
+    if (tokenCache && tokenCache.expiresAt > (now + bufferTime)) {
+        logger.debug('Using cached Spotify access token');
+        return tokenCache.token;
+    }
+
+    // If another request is already fetching a token, wait for it
+    if (isFetchingToken) {
+        logger.debug('Token fetch in progress, waiting...');
+        while (isFetchingToken) {
+            await new Promise(resolve => setTimeout(resolve, 100)); // Wait 100ms
+        }
+        // Check cache again after waiting
+        if (tokenCache && tokenCache.expiresAt > (now + bufferTime)) {
+            logger.debug('Using cached Spotify access token after wait');
+            return tokenCache.token;
+        }
+    }
+
+    // Set fetching flag to prevent concurrent requests
+    isFetchingToken = true;
+
+    try {
+        const spotifyClientId = clientId || process.env.SPOTIFY_CLIENT_ID;
+        const spotifyClientSecret = clientSecret || process.env.SPOTIFY_CLIENT_SECRET;
+
+        if (!spotifyClientId || !spotifyClientSecret) {
+            throw new SpotifyAuthError('Spotify client ID and secret are required. Set SPOTIFY_CLIENT_ID and SPOTIFY_CLIENT_SECRET environment variables.');
+        }
+
+        logger.debug('Fetching new Spotify access token from API');
+
+        const response = await fetch('https://accounts.spotify.com/api/token', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: new URLSearchParams({
+                grant_type: 'client_credentials',
+                client_id: spotifyClientId,
+                client_secret: spotifyClientSecret,
+            }),
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            logger.error(`Spotify token request failed: ${response.status} ${response.statusText}`, errorText);
+            throw new SpotifyAuthError(`Failed to get Spotify access token: ${response.status} ${response.statusText}`);
+        }
+
+        const data: SpotifyTokenResponse = await response.json();
+
+        if (!data.access_token) {
+            logger.error('Spotify token response missing access_token', data);
+            throw new SpotifyAuthError('Invalid response from Spotify: missing access_token');
+        }
+
+        // Cache the token with expiration time
+        const expiresAt = now + (data.expires_in * 1000); // Convert seconds to milliseconds
+        tokenCache = {
+            token: data.access_token,
+            expiresAt: expiresAt
+        };
+
+        logger.debug(`Successfully cached new Spotify access token, expires at ${new Date(expiresAt).toISOString()}`);
+        return data.access_token;
+
+    } catch (error) {
+        // Clear cache on error
+        tokenCache = null;
+
+        if (error instanceof SpotifyAuthError) {
+            throw error;
+        }
+
+        logger.error('Unexpected error getting Spotify access token:', error);
+        throw new SpotifyAuthError(`Failed to get Spotify access token: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    } finally {
+        // Always reset the fetching flag
+        isFetchingToken = false;
+    }
+}
+
+/**
+ * Search for podcast episodes on Spotify
+ * @param query Search query (will be URL encoded)
+ * @param market Market code (default: 'US')
+ * @param limit Maximum number of results (default: 50, max: 50)
+ * @param offset Offset for pagination (default: 0)
+ * @returns Promise<FeedItem[]> Array of podcast episodes in FeedItem format
+ */
+export async function searchSpotifyEpisodes(query: string, market: string = 'US', limit: number = 50, offset: number = 0): Promise<FeedItem[]> {
+    try {
+        logger.debug(`Searching Spotify episodes: "${query}" (market: ${market}, limit: ${limit}, offset: ${offset})`);
+
+        // Get access token
+        const accessToken = await getSpotifyAccessToken();
+
+        // Build search URL
+        const searchParams = new URLSearchParams({
+            q: query,
+            type: 'episode',
+            market: market,
+            limit: Math.min(limit, 50).toString(), // Spotify max is 50
+            offset: offset.toString(),
+        });
+
+        const searchUrl = `https://api.spotify.com/v1/search?${searchParams.toString()}`;
+
+        // Make search request
+        const response = await fetch(searchUrl, {
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${accessToken}`,
+                'Content-Type': 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            logger.error(`Spotify search request failed: ${response.status} ${response.statusText}`, errorText);
+            throw new SpotifySearchError(`Failed to search Spotify episodes: ${response.status} ${response.statusText}`);
+        }
+
+        const data: SpotifySearchResponse = await response.json();
+
+        if (!data.episodes || !data.episodes.items) {
+            logger.error('Spotify search response missing episodes data', data);
+            throw new SpotifySearchError('Invalid response from Spotify: missing episodes data');
+        }
+
+        // Convert Spotify episodes to FeedItem format
+        const feedItems: FeedItem[] = []
+        for (let index = 0; index < data.episodes.items.length; index++) {
+            const episode = data.episodes.items[index];
+            if (!episode) {
+                continue
+            }
+            // Get the best quality image (largest)
+            const imageUrl = episode.images.length > 0
+                ? episode.images.sort((a, b) => b.width - a.width)[0].url
+                : '';
+
+            // Convert duration from milliseconds to HH:MM:SS format
+            const durationMs = episode.duration_ms;
+            const hours = Math.floor(durationMs / 3600000);
+            const minutes = Math.floor((durationMs % 3600000) / 60000);
+            const seconds = Math.floor((durationMs % 60000) / 1000);
+            const duration = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+
+            const feedItem: FeedItem = {
+                Id: episode.id,
+                ChannelId: '', // Spotify doesn't provide channel ID in search results
+                Title: episode.name,
+                HighlightTitle: episode.name,
+                Link: episode.external_urls.spotify,
+                PubDate: episode.release_date,
+                Author: '', // Spotify doesn't provide author in search results
+                InputDate: new Date(episode.release_date),
+                ImageUrl: imageUrl,
+                EnclosureUrl: episode.audio_preview_url || '', // Preview URL if available
+                EnclosureType: 'audio/mpeg', // Assume MP3 for Spotify
+                EnclosureLength: durationMs.toString(),
+                Duration: duration,
+                Episode: '',
+                Explicit: episode.explicit ? 'yes' : 'no',
+                Season: '',
+                EpisodeType: '',
+                Description: episode.html_description,
+                TextDescription: episode.description,
+                ChannelImageUrl: imageUrl,
+                ChannelTitle: '', // Spotify doesn't provide channel title in search results
+                HighlightChannelTitle: '',
+                FeedLink: '',
+                Count: data.episodes.total,
+                TookTime: 0,
+                HasThumbnail: episode.images.length > 0,
+                FeedId: '', // Will be set when we have more context
+                GUID: episode.id,
+                Source: 'spotify',
+                ExcludeFeedId: '',
+                Country: market,
+            };
+
+            feedItems.push(feedItem);
+        }
+
+        logger.debug(`Successfully found ${feedItems.length} Spotify episodes for query "${query}"`);
+        return feedItems;
+
+    } catch (error) {
+        if (error instanceof SpotifyAuthError || error instanceof SpotifySearchError) {
+            throw error;
+        }
+
+        logger.error('Unexpected error searching Spotify episodes:', error);
+        throw new SpotifySearchError(`Failed to search Spotify episodes: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+}
+
+/**
+ * Get detailed information for a specific Spotify episode by ID
+ * @param episodeId Spotify episode ID
+ * @param market Market code (optional, default: 'US')
+ * @returns Promise<FeedItem> Detailed episode information in FeedItem format
+ */
+export async function getSpotifyEpisodeDetail(episodeId: string, market: string = 'US'): Promise<FeedItem> {
+    try {
+        logger.debug(`Getting Spotify episode detail for ID: ${episodeId} (market: ${market})`);
+
+        // Get access token
+        const accessToken = await getSpotifyAccessToken();
+
+        // Build episode detail URL
+        const detailUrl = `https://api.spotify.com/v1/episodes/${episodeId}?market=${market}`;
+
+        // Make detail request
+        const response = await fetch(detailUrl, {
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${accessToken}`,
+                'Content-Type': 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            logger.error(`Spotify episode detail request failed: ${response.status} ${response.statusText}`, errorText);
+            throw new SpotifyEpisodeDetailError(`Failed to get Spotify episode detail: ${response.status} ${response.statusText}`);
+        }
+
+        const episodeDetail: SpotifyEpisodeDetail = await response.json();
+
+        // Validate response
+        if (!episodeDetail.id || !episodeDetail.show) {
+            logger.error('Spotify episode detail response missing required data', episodeDetail);
+            throw new SpotifyEpisodeDetailError('Invalid response from Spotify: missing episode or show data');
+        }
+
+        // Get the best quality episode image
+        const episodeImageUrl = episodeDetail.images.length > 0
+            ? episodeDetail.images.sort((a, b) => b.width - a.width)[0].url
+            : '';
+
+        // Get the best quality show/podcast image
+        const showImageUrl = episodeDetail.show.images.length > 0
+            ? episodeDetail.show.images.sort((a, b) => b.width - a.width)[0].url
+            : '';
+
+        // Convert duration from milliseconds to HH:MM:SS format
+        const durationMs = episodeDetail.duration_ms;
+        const hours = Math.floor(durationMs / 3600000);
+        const minutes = Math.floor((durationMs % 3600000) / 60000);
+        const seconds = Math.floor((durationMs % 60000) / 1000);
+        const duration = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+
+        // Create FeedItem with detailed information
+        const feedItem: FeedItem = {
+            Id: episodeDetail.id,
+            ChannelId: episodeDetail.show.id,
+            Title: episodeDetail.name,
+            HighlightTitle: episodeDetail.name,
+            Link: episodeDetail.external_urls.spotify,
+            PubDate: episodeDetail.release_date,
+            Author: episodeDetail.show.publisher,
+            InputDate: new Date(episodeDetail.release_date),
+            ImageUrl: episodeImageUrl,
+            EnclosureUrl: episodeDetail.audio_preview_url || '', // Preview URL if available
+            EnclosureType: 'audio/mpeg', // Assume MP3 for Spotify
+            EnclosureLength: durationMs.toString(),
+            Duration: duration,
+            Episode: '',
+            Explicit: episodeDetail.explicit ? 'yes' : 'no',
+            Season: '',
+            EpisodeType: '',
+            Description: episodeDetail.html_description,
+            TextDescription: episodeDetail.description,
+            ChannelImageUrl: showImageUrl,
+            ChannelTitle: episodeDetail.show.name,
+            HighlightChannelTitle: episodeDetail.show.name,
+            FeedLink: episodeDetail.show.external_urls.spotify,
+            Count: episodeDetail.show.total_episodes,
+            TookTime: 0,
+            HasThumbnail: episodeDetail.images.length > 0,
+            FeedId: episodeDetail.show.id,
+            GUID: episodeDetail.id,
+            Source: 'spotify',
+            ExcludeFeedId: '',
+            Country: market,
+        };
+
+        logger.debug(`Successfully retrieved detailed information for Spotify episode: ${episodeDetail.name}`);
+        return feedItem;
+
+    } catch (error) {
+        if (error instanceof SpotifyAuthError || error instanceof SpotifyEpisodeDetailError) {
+            throw error;
+        }
+
+        logger.error('Unexpected error getting Spotify episode detail:', error);
+        throw new SpotifyEpisodeDetailError(`Failed to get Spotify episode detail: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+}
+
+/**
+ * Get detailed information for a specific Spotify show (podcast) by ID
+ * @param showId Spotify show ID
+ * @param market Market code (optional, default: 'US')
+ * @returns Promise<FeedChannel> Detailed show information in FeedChannel format
+ */
+export async function getSpotifyShowDetail(showId: string, market: string = 'US'): Promise<FeedChannel> {
+    try {
+        logger.debug(`Getting Spotify show detail for ID: ${showId} (market: ${market})`);
+
+        // Get access token
+        const accessToken = await getSpotifyAccessToken();
+
+        // Build show detail URL
+        const detailUrl = `https://api.spotify.com/v1/shows/${showId}?market=${market}`;
+
+        // Make detail request
+        const response = await fetch(detailUrl, {
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${accessToken}`,
+                'Content-Type': 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            logger.error(`Spotify show detail request failed: ${response.status} ${response.statusText}`, errorText);
+            throw new SpotifyShowDetailError(`Failed to get Spotify show detail: ${response.status} ${response.statusText}`);
+        }
+
+        const showDetail: SpotifyShowDetail = await response.json();
+
+        // Validate response
+        if (!showDetail.id || !showDetail.name) {
+            logger.error('Spotify show detail response missing required data', showDetail);
+            throw new SpotifyShowDetailError('Invalid response from Spotify: missing show data');
+        }
+
+        // Get the best quality show image
+        const showImageUrl = showDetail.images.length > 0
+            ? showDetail.images.sort((a, b) => b.width - a.width)[0].url
+            : '';
+
+        // Get copyright text
+        const copyrightText = showDetail.copyrights.length > 0
+            ? showDetail.copyrights[0].text
+            : '';
+
+        // Get primary language
+        const primaryLanguage = showDetail.languages.length > 0
+            ? showDetail.languages[0]
+            : '';
+
+        // Convert episodes to FeedItem array
+        const feedItems: FeedItem[] = []
+        for (let index = 0; index < showDetail.episodes.items.length; index++) {
+            const episode = showDetail.episodes.items[index];
+            // Get the best quality episode image
+            if (episode === null || episode === undefined) {
+                continue
+            }
+            const episodeImageUrl = episode.images && episode.images.length > 0
+                ? episode.images.sort((a, b) => b.width - a.width)[0].url
+                : showImageUrl; // Fallback to show image
+
+            // Convert duration from milliseconds to HH:MM:SS format
+            const durationMs = episode.duration_ms;
+            const hours = Math.floor(durationMs / 3600000);
+            const minutes = Math.floor((durationMs % 3600000) / 60000);
+            const seconds = Math.floor((durationMs % 60000) / 1000);
+            const duration = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+
+            const feedItem = {
+                Id: episode.id,
+                ChannelId: showDetail.id,
+                Title: episode.name,
+                HighlightTitle: episode.name,
+                Link: episode.external_urls.spotify,
+                PubDate: episode.release_date,
+                Author: showDetail.publisher,
+                InputDate: new Date(episode.release_date),
+                ImageUrl: episodeImageUrl,
+                EnclosureUrl: episode.audio_preview_url || '', // Preview URL if available
+                EnclosureType: 'audio/mpeg', // Assume MP3 for Spotify
+                EnclosureLength: durationMs.toString(),
+                Duration: duration,
+                Episode: '',
+                Explicit: episode.explicit ? 'yes' : 'no',
+                Season: '',
+                EpisodeType: '',
+                Description: episode.html_description,
+                TextDescription: episode.description,
+                ChannelImageUrl: showImageUrl,
+                ChannelTitle: showDetail.name,
+                HighlightChannelTitle: showDetail.name,
+                FeedLink: showDetail.external_urls.spotify,
+                Count: showDetail.total_episodes,
+                TookTime: 0,
+                HasThumbnail: episode.images.length > 0,
+                FeedId: showDetail.id,
+                GUID: episode.id,
+                Source: 'spotify',
+                ExcludeFeedId: '',
+                Country: market,
+            };
+            feedItems.push(feedItem);
+        }
+
+        // Create FeedChannel from Spotify show data
+        const feedChannel: FeedChannel = {
+            Id: showDetail.id,
+            Title: showDetail.name,
+            ChannelDesc: showDetail.html_description,
+            TextChannelDesc: showDetail.description,
+            ImageUrl: showImageUrl,
+            Link: showDetail.external_urls.spotify,
+            FeedLink: showDetail.external_urls.spotify,
+            FeedType: 'spotify',
+            Categories: [], // Spotify doesn't provide categories in show detail
+            Author: showDetail.publisher,
+            OwnerName: showDetail.publisher, // Use publisher as owner name
+            OwnerEmail: '', // Spotify doesn't provide email
+            Items: feedItems, // Converted episodes
+            Count: showDetail.total_episodes,
+            Copyright: copyrightText,
+            Language: primaryLanguage,
+            TookTime: 0,
+            HasThumbnail: showDetail.images.length > 0,
+        };
+
+        logger.debug(`Successfully retrieved and converted Spotify show: ${showDetail.name} (${feedItems.length} episodes)`);
+        return feedChannel;
+
+    } catch (error) {
+        if (error instanceof SpotifyAuthError || error instanceof SpotifyShowDetailError) {
+            throw error;
+        }
+
+        logger.error('Unexpected error getting Spotify show detail:', error);
+        throw new SpotifyShowDetailError(`Failed to get Spotify show detail: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+}
+
+/**
+ * Get episodes for a specific Spotify show (podcast) by ID
+ * @param showId Spotify show ID
+ * @param market Market code (optional, default: 'US')
+ * @param limit Maximum number of results (default: 50, max: 50)
+ * @param offset Offset for pagination (default: 0)
+ * @returns Promise<FeedItem[]> Array of podcast episodes in FeedItem format
+ */
+export async function getSpotifyShowEpisodes(showId: string, market: string = 'US', limit: number = 50, offset: number = 0): Promise<FeedItem[]> {
+    try {
+        logger.debug(`Getting Spotify show episodes for show ID: ${showId} (market: ${market}, limit: ${limit}, offset: ${offset})`);
+
+        // Get access token
+        const accessToken = await getSpotifyAccessToken();
+
+        // Build show episodes URL
+        const episodesParams = new URLSearchParams({
+            market: market,
+            limit: Math.min(limit, 50).toString(), // Spotify max is 50
+            offset: offset.toString(),
+        });
+
+        const episodesUrl = `https://api.spotify.com/v1/shows/${showId}/episodes?${episodesParams.toString()}`;
+
+        // Make episodes request
+        const response = await fetch(episodesUrl, {
+            method: 'GET',
+            headers: {
+                'Authorization': `Bearer ${accessToken}`,
+                'Content-Type': 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            const errorText = await response.text();
+            logger.error(`Spotify show episodes request failed: ${response.status} ${response.statusText}`, errorText);
+            throw new SpotifyShowEpisodesError(`Failed to get Spotify show episodes: ${response.status} ${response.statusText}`);
+        }
+
+        const data: SpotifySearchResponse['episodes'] = await response.json();
+
+        // Validate response
+        if (!data.items) {
+            logger.error('Spotify show episodes response missing items data', data);
+            throw new SpotifyShowEpisodesError('Invalid response from Spotify: missing episodes items data');
+        }
+
+        // Convert Spotify episodes to FeedItem format
+        const feedItems: FeedItem[] = []
+        for (let index = 0; index < data.items.length; index++) {
+            const episode = data.items[index];
+            if (!episode) {
+                continue
+            }
+            // Get the best quality image (largest)
+            const imageUrl = episode.images.length > 0
+                ? episode.images.sort((a, b) => b.width - a.width)[0].url
+                : '';
+
+            // Convert duration from milliseconds to HH:MM:SS format
+            const durationMs = episode.duration_ms;
+            const hours = Math.floor(durationMs / 3600000);
+            const minutes = Math.floor((durationMs % 3600000) / 60000);
+            const seconds = Math.floor((durationMs % 60000) / 1000);
+            const duration = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+
+            const feedItem: FeedItem = {
+                Id: episode.id,
+                ChannelId: showId, // Use the showId as channel ID
+                Title: episode.name,
+                HighlightTitle: episode.name,
+                Link: episode.external_urls.spotify,
+                PubDate: episode.release_date,
+                Author: '', // Show episodes endpoint doesn't provide author/publisher
+                InputDate: new Date(episode.release_date),
+                ImageUrl: imageUrl,
+                EnclosureUrl: episode.audio_preview_url || '', // Preview URL if available
+                EnclosureType: 'audio/mpeg', // Assume MP3 for Spotify
+                EnclosureLength: durationMs.toString(),
+                Duration: duration,
+                Episode: '',
+                Explicit: episode.explicit ? 'yes' : 'no',
+                Season: '',
+                EpisodeType: '',
+                Description: episode.html_description,
+                TextDescription: episode.description,
+                ChannelImageUrl: imageUrl, // Use episode image as channel image fallback
+                ChannelTitle: '', // Show episodes endpoint doesn't provide show title
+                HighlightChannelTitle: '',
+                FeedLink: '', // Show episodes endpoint doesn't provide show URL
+                Count: data.total,
+                TookTime: 0,
+                HasThumbnail: episode.images.length > 0,
+                FeedId: showId, // Use the showId as feed ID
+                GUID: episode.id,
+                Source: 'spotify',
+                ExcludeFeedId: '',
+                Country: market,
+            };
+
+            feedItems.push(feedItem);
+        }
+
+        logger.debug(`Successfully retrieved ${feedItems.length} episodes for Spotify show: ${showId}`);
+        return feedItems;
+
+    } catch (error) {
+        if (error instanceof SpotifyAuthError || error instanceof SpotifyShowEpisodesError) {
+            throw error;
+        }
+
+        logger.error('Unexpected error getting Spotify show episodes:', error);
+        throw new SpotifyShowEpisodesError(`Failed to get Spotify show episodes: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+}


### PR DESCRIPTION
- Replaced iTunes API calls with Spotify equivalents in subscription search, listen later, and playlist item routes
- Updated imports and logic to use Spotify for episode searching and detail retrieval
- Ensures compatibility with Spotify's data structure for podcast episodes