### PR TITLE
fix: AudioPlayer SSR crash & prisma import ordering

### DIFF
--- a/libs/listen_later.ts
+++ b/libs/listen_later.ts
@@ -64,6 +64,7 @@ export async function getListenLaterListByUserIdServer(userId: string, page: num
 
         return { code: 0, message: 'OK', data: queryListData }
     } catch (err) {
+        console.error('getListenLaterListByUserIdServer error:', err)
         return { code: 1, message: String(err), data: [] }
     }
 }

--- a/libs/playlist.ts
+++ b/libs/playlist.ts
@@ -110,6 +110,7 @@ export async function getUserPlaylistByUserIdServer(userId: string, page: number
         const data = await queryUserPlaylistListByUserId(userId, offset, limit)
         return { code: 0, message: 'Ok', data }
     } catch (err) {
+        console.error('getUserPlaylistByUserIdServer error:', err)
         return { code: 1, message: String(err), data: [] }
     }
 }
@@ -138,6 +139,7 @@ export async function getPlaylistInfoByIdServer(playlistId: string): Promise<{ c
 
         return { code: 0, message: 'OK', data: playlistInfoDto }
     } catch (err) {
+        console.error('getPlaylistInfoByIdServer error:', err)
         return { code: 1, message: String(err), data: null }
     }
 }
@@ -164,6 +166,7 @@ export async function getPlaylistItemListByUserIdServer(userId: string, playlist
         const playlist = await queryPlaylistItemsByPlaylistId(playlistId)
         return { code: 0, message: 'success', data: { userInfo, playlist: playlist as unknown as FeedItem[] } }
     } catch (err) {
+        console.error('getPlaylistItemListByUserIdServer error:', err)
         return { code: 1, message: String(err), data: null }
     }
 }

--- a/libs/subscription.ts
+++ b/libs/subscription.ts
@@ -107,6 +107,7 @@ export async function getUserSubscriptionListServer(userId: string): Promise<{ c
         const data = await queryUserKeywordSubscriptionList(userId, 0, 100)
         return { code: 0, message: 'OK', data }
     } catch (err) {
+        console.error('getUserSubscriptionListServer error:', err)
         return { code: 1, message: String(err), data: [] }
     }
 }
@@ -119,6 +120,7 @@ export async function getUserKeywordSubscriptionItemListServer(userId: string, k
         const data = await queryKeywordSubscriptionFeedItemList(userId, keyword, usInfo.Source, usInfo.Country, usInfo.ExcludeFeedId, offset, limit)
         return { code: 0, message: 'ok', data }
     } catch (err) {
+        console.error('getUserKeywordSubscriptionItemListServer error:', err)
         return { code: 1, message: String(err), data: [] }
     }
 }

--- a/libs/user.ts
+++ b/libs/user.ts
@@ -1,3 +1,4 @@
+import prisma from './prisma'
 
 export type ServerUserInfo = {
     id: string;
@@ -70,9 +71,6 @@ export const getUserInfoFromServer = async (userId: string): Promise<{ code: num
         data: respJson.data
     }
 }
-
-import prisma from './prisma'
-
 export async function getUserInfoByIdServer(userId: string): Promise<{ code: number, message: string, data: ServerUserInfo | null }> {
     try {
         const user = await prisma.user_info.findUnique({ where: { id: userId } })
@@ -92,6 +90,7 @@ export async function getUserInfoByIdServer(userId: string): Promise<{ code: num
             }
         }
     } catch (err) {
+        console.error('getUserInfoByIdServer error:', err)
         return { code: 1, message: String(err), data: null }
     }
 }


### PR DESCRIPTION
## Summary

Fixes two production issues discovered after the SSR migration.

### Fixes

1. **`AudioPlayer.tsx`** - `window.matchMedia()` was called at render level, crashing SSR with `ReferenceError: window is not defined`. Moved into `useState` initializer with `typeof window` guard.

2. **`libs/user.ts`** - `import prisma from './prisma'` was placed after multiple exports (line 74). This caused SWC bundling issues on Vercel production runtime, making Prisma queries silently fail. Moved to file top.

3. **Error logging** - Added `console.error` in all `*Server()` function catch blocks for visibility in Vercel logs.

### Commits
- `fix: move prisma import to top of user.ts, add error logging to all server functions`
- `fix: guard window.matchMedia in AudioPlayer against SSR`