### PR TITLE
fix: URL-encoded keyword not decoded before DB query

### DIFF
--- a/app/subscription/[userId]/[keyword]/page.tsx
+++ b/app/subscription/[userId]/[keyword]/page.tsx
@@ -26,7 +26,7 @@ export default async function Page({ params, searchParams }: Props) {
         nickname = getTempNickname(userResp.data)
     }
 
-    const subResp = await getUserKeywordSubscriptionItemListServer(userId, keyword, page)
+    const subResp = await getUserKeywordSubscriptionItemListServer(userId, decodedKeyword, page)
     if (subResp.code === 0) {
         itemList = subResp.data
         if (itemList.length > 0) {


### PR DESCRIPTION
## Summary

`params.keyword` from the URL comes encoded (e.g. `%E8%B5%9B%E5%8D%9A%E6%9C%8B%E5%85%8B` for 赛博朋克). The server page was passing the encoded value directly to the Prisma query, which compares against human-readable text in the database — causing `Subscription not found`.

## Fix

`app/subscription/[userId]/[keyword]/page.tsx` — pass `decodedKeyword` (already decoded via `decodeURIComponent`) to `getUserKeywordSubscriptionItemListServer` instead of the raw `keyword`.