### PR TITLE
App Store Compliance: Privacy Policy & Terms of Service Pages

### DIFF
--- a/app/privacy/page.tsx
+++ b/app/privacy/page.tsx
@@ -1,0 +1,232 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+
+type Lang = 'en' | 'zh'
+
+const content: Record<Lang, {
+    title: string
+    lastUpdated: string
+    sections: { heading: string; paragraphs: string[] }[]
+    contactEmail: string
+}> = {
+    en: {
+        title: 'Privacy Policy',
+        lastUpdated: 'Last updated: May 2026',
+        contactEmail: 'support@porkast.com',
+        sections: [
+            {
+                heading: 'Information We Collect',
+                paragraphs: [
+                    'Email address: Used for authentication via one-time verification codes sent to your email.',
+                    'Optional nickname: You may provide a display name.',
+                    'Subscription keywords: Topics or keywords you choose to follow for podcast discovery.',
+                    'Listen Later list: Episodes you save for later listening.',
+                    'Playlists: Names and episodes you organize into playlists.',
+                    'Verification codes: Temporary codes used for login; stored for 10 minutes then deleted.',
+                ]
+            },
+            {
+                heading: 'Information We Do NOT Collect',
+                paragraphs: [
+                    'Precise location data',
+                    'Device identifiers (IDFA, IDFV)',
+                    'Contacts, photos, or other personal files',
+                    'Health, financial, or biometric data',
+                ]
+            },
+            {
+                heading: 'How We Use Your Information',
+                paragraphs: [
+                    'Authentication: Verify your identity using email-based one-time codes.',
+                    'Podcast Discovery: Find new podcast episodes matching your subscribed keywords.',
+                    'Personalization: Display your playlists, listen later queue, and subscriptions.',
+                    'Notifications: Send email updates about new episodes matching your subscriptions.',
+                ]
+            },
+            {
+                heading: 'Third-Party Services',
+                paragraphs: [
+                    'Resend: Email delivery service for sending verification codes and notifications. Their privacy policy: https://resend.com/legal/privacy-policy',
+                    'Apple iTunes API: Used for podcast search and metadata retrieval.',
+                    'Spotify API: Used for podcast search and metadata retrieval.',
+                    'Telegram Bot API: Optional integration for podcast discovery via Telegram.',
+                    'These services receive only the data necessary to perform their functions (e.g., your email address is shared with Resend solely for delivering verification codes).',
+                ]
+            },
+            {
+                heading: 'Data Storage and Security',
+                paragraphs: [
+                    'Your data is stored on secure PostgreSQL database servers.',
+                    'Authentication uses JWT tokens, stored securely in your device\'s Keychain (iOS) or local storage.',
+                    'Session tokens expire after 30 days of inactivity.',
+                    'We implement reasonable security measures to protect your personal information.',
+                ]
+            },
+            {
+                heading: 'Your Rights',
+                paragraphs: [
+                    'Access your data at any time through the app.',
+                    'Delete your data by removing subscriptions, playlists, or listen later items.',
+                    'Request account deletion by contacting us at support@porkast.com.',
+                ]
+            },
+            {
+                heading: 'Children\'s Privacy',
+                paragraphs: [
+                    'Our service is not directed to children under the age of 13. We do not knowingly collect personal information from children. If you believe we have inadvertently collected such information, please contact us.',
+                ]
+            },
+            {
+                heading: 'Changes to This Policy',
+                paragraphs: [
+                    'We may update this Privacy Policy from time to time. Changes will be posted on this page with an updated "Last updated" date. Continued use of the service after changes constitutes acceptance.',
+                ]
+            },
+            {
+                heading: 'Contact Us',
+                paragraphs: [
+                    'If you have questions about this Privacy Policy, contact us at:',
+                    'support@porkast.com',
+                ]
+            },
+        ]
+    },
+    zh: {
+        title: '隐私政策',
+        lastUpdated: '最后更新：2026年5月',
+        contactEmail: 'support@porkast.com',
+        sections: [
+            {
+                heading: '我们收集的信息',
+                paragraphs: [
+                    '电子邮件地址：用于通过发送到您邮箱的一次性验证码进行身份认证。',
+                    '可选的昵称：您可以设置显示名称。',
+                    '订阅关键词：您选择关注的话题或关键词，用于发现播客。',
+                    '稍后收听列表：您保存以便稍后收听的节目。',
+                    '播放列表：您创建的播放列表名称及其中包含的节目。',
+                    '验证码：用于登录的一次性临时代码，存储10分钟后自动删除。',
+                ]
+            },
+            {
+                heading: '我们不会收集的信息',
+                paragraphs: [
+                    '精确位置数据',
+                    '设备标识符（IDFA、IDFV）',
+                    '通讯录、照片或其他个人文件',
+                    '健康、财务或生物识别数据',
+                ]
+            },
+            {
+                heading: '我们如何使用您的信息',
+                paragraphs: [
+                    '身份认证：使用基于邮箱的一次性验证码验证您的身份。',
+                    '播客发现：根据您的订阅关键词为您找到匹配的新播客节目。',
+                    '个性化：展示您的播放列表、稍后收听队列和订阅内容。',
+                    '通知：在匹配您订阅的新节目出现时发送邮件更新。',
+                ]
+            },
+            {
+                heading: '第三方服务',
+                paragraphs: [
+                    'Resend：用于发送验证码和通知的邮件投递服务。其隐私政策：https://resend.com/legal/privacy-policy',
+                    'Apple iTunes API：用于播客搜索和元数据检索。',
+                    'Spotify API：用于播客搜索和元数据检索。',
+                    'Telegram Bot API：可选的机器人集成，用于在 Telegram 中搜索和订阅播客。',
+                    '这些服务仅接收执行其功能所必需的数据（例如，您的电子邮件地址仅共享给 Resend 用于投递验证码）。',
+                ]
+            },
+            {
+                heading: '数据存储与安全',
+                paragraphs: [
+                    '您的数据存储在安全的 PostgreSQL 数据库服务器上。',
+                    '身份认证使用 JWT 令牌，安全地存储在您设备的 Keychain（iOS）或本地存储中。',
+                    '会话令牌在30天不活动后过期。',
+                    '我们采用合理的安全措施保护您的个人信息。',
+                ]
+            },
+            {
+                heading: '您的权利',
+                paragraphs: [
+                    '访问您的数据：随时通过应用查看您的订阅、播放列表等。',
+                    '删除您的数据：取消订阅、删除播放列表或移除稍后收听项目。',
+                    '请求删除账户：通过 support@porkast.com 联系我们。',
+                ]
+            },
+            {
+                heading: '儿童隐私',
+                paragraphs: [
+                    '我们的服务不面向13岁以下儿童。我们不会有意收集儿童的个人信息。如果您认为我们无意中收集了此类信息，请与我们联系。',
+                ]
+            },
+            {
+                heading: '本政策的变更',
+                paragraphs: [
+                    '我们可能会不时更新本隐私政策。变更将在本页面发布，并更新"最后更新"日期。变更后继续使用服务即表示您接受修改后的政策。',
+                ]
+            },
+            {
+                heading: '联系我们',
+                paragraphs: [
+                    '如对本隐私政策有任何疑问，请通过以下方式联系我们：',
+                    'support@porkast.com',
+                ]
+            },
+        ]
+    },
+}
+
+export default function PrivacyPage() {
+    const [lang, setLang] = useState<Lang>('en')
+
+    useEffect(() => {
+        const params = new URLSearchParams(window.location.search)
+        if (params.get('lang') === 'zh') setLang('zh')
+    }, [])
+
+    const t = content[lang]
+
+    return (
+        <>
+            <Header hideSearchBtn={true}>
+                <div className="w-full flex justify-center min-h-screen mt-20">
+                    <div className="w-full max-w-3xl pt-24 px-6 pb-12">
+                        <div className="bg-base-200 p-8 rounded-xl shadow-lg">
+                            <div className="flex justify-end mb-6">
+                                <div className="join">
+                                    <button
+                                        className={`join-item btn btn-sm ${lang === 'en' ? 'btn-active' : ''}`}
+                                        onClick={() => setLang('en')}
+                                    >
+                                        EN
+                                    </button>
+                                    <button
+                                        className={`join-item btn btn-sm ${lang === 'zh' ? 'btn-active' : ''}`}
+                                        onClick={() => setLang('zh')}
+                                    >
+                                        中文
+                                    </button>
+                                </div>
+                            </div>
+
+                            <h1 className="text-2xl font-bold mb-2">{t.title}</h1>
+                            <p className="text-sm text-base-content/60 mb-8">{t.lastUpdated}</p>
+
+                            {t.sections.map((section, i) => (
+                                <div key={i} className="mb-6">
+                                    <h2 className="text-lg font-semibold mb-2">{section.heading}</h2>
+                                    {section.paragraphs.map((p, j) => (
+                                        <p key={j} className="text-base text-base-content/80 mb-1">{p}</p>
+                                    ))}
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                </div>
+            </Header>
+            <Footer />
+        </>
+    )
+}

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,0 +1,250 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+
+type Lang = 'en' | 'zh'
+
+const content: Record<Lang, {
+    title: string
+    lastUpdated: string
+    sections: { heading: string; paragraphs: string[] }[]
+    contactEmail: string
+}> = {
+    en: {
+        title: 'Terms of Service',
+        lastUpdated: 'Last updated: May 2026',
+        contactEmail: 'support@porkast.com',
+        sections: [
+            {
+                heading: 'Acceptance of Terms',
+                paragraphs: [
+                    'By accessing or using Porkast ("the Service"), you agree to be bound by these Terms of Service. If you do not agree, do not use the Service.',
+                ]
+            },
+            {
+                heading: 'Description of Service',
+                paragraphs: [
+                    'Porkast is a podcast discovery and personalization platform that allows you to:',
+                    'Search for podcasts across multiple sources',
+                    'Subscribe to keywords and topics',
+                    'Create and manage playlists',
+                    'Save episodes to your Listen Later list',
+                    'Receive notifications for new matching episodes',
+                ]
+            },
+            {
+                heading: 'User Accounts',
+                paragraphs: [
+                    'You must provide a valid email address to create an account.',
+                    'You are responsible for maintaining the confidentiality of your account.',
+                    'You must not share your verification codes with others.',
+                    'You may delete your account by contacting us at support@porkast.com.',
+                ]
+            },
+            {
+                heading: 'User Content and Conduct',
+                paragraphs: [
+                    'You are responsible for the keywords you subscribe to and the content you save.',
+                    'You agree not to use the Service for any unlawful purpose.',
+                    'You agree not to attempt to gain unauthorized access to our systems.',
+                ]
+            },
+            {
+                heading: 'Intellectual Property Rights',
+                paragraphs: [
+                    'Podcast content accessible through Porkast is owned by the respective podcast creators and rights holders. Porkast does not claim ownership over any third-party podcast content.',
+                    'The Porkast name, logo, and app interface are our intellectual property.',
+                ]
+            },
+            {
+                heading: 'Third-Party Services',
+                paragraphs: [
+                    'Our Service integrates with third-party platforms (Apple Podcasts, Spotify, Telegram). Your use of these platforms is governed by their respective terms of service. Porkast is not responsible for third-party content.',
+                ]
+            },
+            {
+                heading: 'Disclaimer of Warranties',
+                paragraphs: [
+                    'THE SERVICE IS PROVIDED "AS IS" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED. WE DO NOT GUARANTEE THAT THE SERVICE WILL BE UNINTERRUPTED, ERROR-FREE, OR COMPLETELY SECURE.',
+                ]
+            },
+            {
+                heading: 'Limitation of Liability',
+                paragraphs: [
+                    'TO THE MAXIMUM EXTENT PERMITTED BY LAW, PORKAST SHALL NOT BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES ARISING FROM YOUR USE OF THE SERVICE.',
+                ]
+            },
+            {
+                heading: 'Termination',
+                paragraphs: [
+                    'We reserve the right to suspend or terminate your access to the Service at our discretion, without prior notice, for conduct that we believe violates these Terms or is harmful to other users or the Service.',
+                ]
+            },
+            {
+                heading: 'Governing Law',
+                paragraphs: [
+                    'These Terms are governed by the laws of China and the United States, depending on your jurisdiction. Any disputes shall be resolved in the appropriate courts of the applicable jurisdiction.',
+                ]
+            },
+            {
+                heading: 'Changes to Terms',
+                paragraphs: [
+                    'We may modify these Terms at any time. Changes will be posted on this page. Continued use after changes constitutes your acceptance of the new Terms.',
+                ]
+            },
+            {
+                heading: 'Contact Information',
+                paragraphs: [
+                    'For questions about these Terms, contact us at:',
+                    'support@porkast.com',
+                ]
+            },
+        ]
+    },
+    zh: {
+        title: '服务条款',
+        lastUpdated: '最后更新：2026年5月',
+        contactEmail: 'support@porkast.com',
+        sections: [
+            {
+                heading: '条款接受',
+                paragraphs: [
+                    '访问或使用 Porkast（以下简称"服务"），即表示您同意受本服务条款的约束。如不同意，请勿使用本服务。',
+                ]
+            },
+            {
+                heading: '服务说明',
+                paragraphs: [
+                    'Porkast 是一个播客发现与个性化平台，允许您：',
+                    '跨多个来源搜索播客',
+                    '订阅关键词和话题',
+                    '创建和管理播放列表',
+                    '将节目保存到稍后收听列表',
+                    '接收匹配新节目的通知',
+                ]
+            },
+            {
+                heading: '用户账户',
+                paragraphs: [
+                    '您必须提供有效的电子邮件地址以创建账户。',
+                    '您有责任维护账户的机密性。',
+                    '您不得与他人分享您的验证码。',
+                    '您可以通过 support@porkast.com 联系我们删除您的账户。',
+                ]
+            },
+            {
+                heading: '用户内容与行为',
+                paragraphs: [
+                    '您对自己订阅的关键词和保存的内容负责。',
+                    '您同意不将本服务用于任何非法目的。',
+                    '您同意不试图未经授权访问我们的系统。',
+                ]
+            },
+            {
+                heading: '知识产权',
+                paragraphs: [
+                    '通过 Porkast 访问的播客内容归各自的播客创作者和权利持有人所有。Porkast 不对任何第三方播客内容主张所有权。',
+                    'Porkast 名称、标志和应用界面是我们的知识产权。',
+                ]
+            },
+            {
+                heading: '第三方服务',
+                paragraphs: [
+                    '我们的服务集成了第三方平台（Apple Podcasts、Spotify、Telegram）。您对这些平台的使用受其各自的服务条款约束。Porkast 不对第三方内容负责。',
+                ]
+            },
+            {
+                heading: '免责声明',
+                paragraphs: [
+                    '本服务按"原样"提供，不提供任何明示或暗示的保证。我们不保证服务不会中断、没有错误或完全安全。',
+                ]
+            },
+            {
+                heading: '责任限制',
+                paragraphs: [
+                    '在法律允许的最大范围内，Porkast 不对因使用本服务而产生的任何间接、附带、特殊、后果性或惩罚性损害赔偿承担责任。',
+                ]
+            },
+            {
+                heading: '终止',
+                paragraphs: [
+                    '我们保留自行决定暂停或终止您访问本服务的权利，恕不另行通知，针对我们认为违反本条款或对其他用户或服务有害的行为。',
+                ]
+            },
+            {
+                heading: '适用法律',
+                paragraphs: [
+                    '本条款受中国和美国法律管辖，具体取决于您所在的司法管辖区。任何争议应在适用司法管辖区的适当法院解决。',
+                ]
+            },
+            {
+                heading: '条款变更',
+                paragraphs: [
+                    '我们可能随时修改本条款。变更将在本页面发布。变更后继续使用即表示您接受新条款。',
+                ]
+            },
+            {
+                heading: '联系方式',
+                paragraphs: [
+                    '如对本条款有任何疑问，请通过以下方式联系我们：',
+                    'support@porkast.com',
+                ]
+            },
+        ]
+    },
+}
+
+export default function TermsPage() {
+    const [lang, setLang] = useState<Lang>('en')
+
+    useEffect(() => {
+        const params = new URLSearchParams(window.location.search)
+        if (params.get('lang') === 'zh') setLang('zh')
+    }, [])
+
+    const t = content[lang]
+
+    return (
+        <>
+            <Header hideSearchBtn={true}>
+                <div className="w-full flex justify-center min-h-screen mt-20">
+                    <div className="w-full max-w-3xl pt-24 px-6 pb-12">
+                        <div className="bg-base-200 p-8 rounded-xl shadow-lg">
+                            <div className="flex justify-end mb-6">
+                                <div className="join">
+                                    <button
+                                        className={`join-item btn btn-sm ${lang === 'en' ? 'btn-active' : ''}`}
+                                        onClick={() => setLang('en')}
+                                    >
+                                        EN
+                                    </button>
+                                    <button
+                                        className={`join-item btn btn-sm ${lang === 'zh' ? 'btn-active' : ''}`}
+                                        onClick={() => setLang('zh')}
+                                    >
+                                        中文
+                                    </button>
+                                </div>
+                            </div>
+
+                            <h1 className="text-2xl font-bold mb-2">{t.title}</h1>
+                            <p className="text-sm text-base-content/60 mb-8">{t.lastUpdated}</p>
+
+                            {t.sections.map((section, i) => (
+                                <div key={i} className="mb-6">
+                                    <h2 className="text-lg font-semibold mb-2">{section.heading}</h2>
+                                    {section.paragraphs.map((p, j) => (
+                                        <p key={j} className="text-base text-base-content/80 mb-1">{p}</p>
+                                    ))}
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                </div>
+            </Header>
+            <Footer />
+        </>
+    )
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -153,6 +153,8 @@ export default function Header(props: HeaderProps) {
                                                 </label>
                                                 <ul tabIndex={0} className="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-200 rounded-box w-52">
                                                     {/* <li><a>Settings</a></li> */}
+                                                    <li><Link href="/privacy" className="text-base">Privacy Policy</Link></li>
+                                                    <li><Link href="/terms" className="text-base">Terms of Service</Link></li>
                                                     <li onClick={handleLogout}>
                                                         <a className="text-base font-bold w-48">
                                                             <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="lucide lucide-log-out"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" /><polyline points="16 17 21 12 16 7" /><line x1="21" x2="9" y1="12" y2="12" /></svg>
@@ -164,7 +166,11 @@ export default function Header(props: HeaderProps) {
                                                     </li>
                                                 </ul>
                                             </div>
-                                        ) : <li><Link className="text-base btn btn-primary" href={"/signin"}>Sign In</Link></li>
+                                        ) : <>
+                                                    <li><Link href="/privacy" className="text-base btn btn-ghost">Privacy</Link></li>
+                                                    <li><Link href="/terms" className="text-base btn btn-ghost">Terms</Link></li>
+                                                    <li><Link className="text-base btn btn-primary" href={"/signin"}>Sign In</Link></li>
+                                                </>
                                     }
                                 </ul>
                             </div>
@@ -235,6 +241,16 @@ export default function Header(props: HeaderProps) {
                             )
                         }
                         <div className="absolute bottom-6 w-72">
+                            <li>
+                                <Link href="/privacy" className="text-base font-bold">
+                                    Privacy Policy
+                                </Link>
+                            </li>
+                            <li>
+                                <Link href="/terms" className="text-base font-bold">
+                                    Terms of Service
+                                </Link>
+                            </li>
                             {
                                 isLogin ? (
                                     <li onClick={handleLogout}>


### PR DESCRIPTION
## Summary
- Added bilingual (EN/ZH) **Privacy Policy** page at `/privacy`
- Added bilingual (EN/ZH) **Terms of Service** page at `/terms`
- Added navigation links in Header (desktop dropdown, desktop nav, mobile sidebar)
- Supports `?lang=zh` query param for direct Chinese language links

## Details
Both pages include language toggle buttons (EN / 中文), default to English, and are designed for iOS App Store compliance requirements. Content covers all data collection practices (email auth, subscriptions, playlists, listen later), third-party services (Resend, Apple/Spotify API, Telegram), and governing law (China & US).

Contact email: support@porkast.com