### PR TITLE
feat: add rate limiting to email OTP send-code endpoint

### DIFF
--- a/app/api/auth/send-code/route.ts
+++ b/app/api/auth/send-code/route.ts
@@ -11,6 +11,24 @@ export async function POST(request: NextRequest) {
             return NextResponse.json({ code: 1, message: 'Invalid email address', data: null }, { status: 400 });
         }
 
+        // Rate limit: check if a token was sent recently
+        const recentToken = await prisma.verification_token.findFirst({
+            where: { email },
+            orderBy: { created_at: 'desc' },
+        });
+
+        if (recentToken) {
+            const elapsed = Math.floor((Date.now() - recentToken.created_at.getTime()) / 1000);
+            const remaining = 60 - elapsed;
+            if (remaining > 0) {
+                return NextResponse.json({
+                    code: 1,
+                    message: `Please wait ${remaining} seconds and try again.`,
+                    data: { retryAfter: remaining },
+                }, { status: 429 });
+            }
+        }
+
         // Generate a 6-digit random code
         const code = Math.floor(100000 + Math.random() * 900000).toString();
 


### PR DESCRIPTION
## Summary
- Add 60-second cooldown between email OTP requests in the Next.js send-code API route
- Return 429 with `retryAfter` in response data when within cooldown window

## Changes
- `app/api/auth/send-code/route.ts` — check recent token before sending new code