### PR TITLE
feat: add infinite-scroll feed item list to subscription page

### DIFF
--- a/app/api/subscription/items/route.ts
+++ b/app/api/subscription/items/route.ts
@@ -1,0 +1,28 @@
+import { queryUserAllSubscriptionFeedItemList } from "@/libs/db/subscription";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(request: NextRequest) {
+
+    const resp: JsonResponse = {
+        code: 0,
+        message: '',
+        data: null
+    }
+    const searchParams = request.nextUrl.searchParams
+    const userId = searchParams.get('userId')
+    const limit = Number(searchParams.get('limit') || 10)
+    const offset = Number(searchParams.get('offset') || 0)
+
+    if (!userId) {
+        resp.code = 1
+        resp.message = 'User ID is required'
+        return NextResponse.json(resp)
+    }
+
+    const { items } = await queryUserAllSubscriptionFeedItemList(userId, offset, limit)
+
+    resp.code = 0
+    resp.message = 'OK'
+    resp.data = items
+    return NextResponse.json(resp)
+}

--- a/app/subscription/[userId]/SubscriptionFeedList.tsx
+++ b/app/subscription/[userId]/SubscriptionFeedList.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import { useEffect, useRef, useState } from "react"
+import EpisodeCard from "@/components/EpisodeCard"
+import { FeedItem } from "@/types/feed_item"
+import { getUserAllSubscriptionItems } from "@/libs/subscription"
+
+type Props = {
+    userId: string
+    initialItems: FeedItem[]
+    initialTotalCount: number
+}
+
+export default function SubscriptionFeedList({ userId, initialItems, initialTotalCount }: Props) {
+
+    const [items, setItems] = useState<FeedItem[]>(initialItems)
+    const [hasMore, setHasMore] = useState(initialItems.length === 10)
+    const [loading, setLoading] = useState(false)
+
+    const sentinelRef = useRef<HTMLDivElement>(null)
+    const offsetRef = useRef(initialItems.length)
+    const loadingRef = useRef(false)
+    const hasMoreRef = useRef(initialItems.length === 10)
+
+    useEffect(() => {
+        loadingRef.current = loading
+    }, [loading])
+
+    useEffect(() => {
+        hasMoreRef.current = hasMore
+    }, [hasMore])
+
+    useEffect(() => {
+        const observer = new IntersectionObserver((entries) => {
+            if (entries[0].isIntersecting && hasMoreRef.current && !loadingRef.current) {
+                loadMore()
+            }
+        }, { threshold: 0.1 })
+
+        const sentinel = sentinelRef.current
+        if (sentinel) {
+            observer.observe(sentinel)
+        }
+
+        return () => {
+            observer.disconnect()
+        }
+    }, [])
+
+    const loadMore = async () => {
+        setLoading(true)
+        loadingRef.current = true
+        const resp = await getUserAllSubscriptionItems(userId, offsetRef.current, 10)
+        if (resp.code === 0 && resp.data.length > 0) {
+            setItems(prev => [...prev, ...resp.data])
+            offsetRef.current += resp.data.length
+            if (resp.data.length < 10) {
+                setHasMore(false)
+                hasMoreRef.current = false
+            }
+        } else {
+            setHasMore(false)
+            hasMoreRef.current = false
+        }
+        setLoading(false)
+    }
+
+    if (initialTotalCount === 0) {
+        return null
+    }
+
+    return (
+        <div className="mt-12">
+            <div className="text-neutral-500 text-sm mb-6 ml-2">{initialTotalCount} episodes</div>
+            {
+                items.map((item, index) => {
+                    return (
+                        <EpisodeCard key={item.GUID + '-' + index} data={{
+                            itemId: item.GUID,
+                            channelId: item.FeedId,
+                            title: item.Title,
+                            description: item.Description,
+                            image: item.ImageUrl,
+                            link: item.Link,
+                            rssLink: item.FeedLink,
+                            channelName: item.ChannelTitle,
+                            authorName: item.Author,
+                            pubDate: item.PubDate,
+                            audioLength: item.Duration,
+                            audioSrc: item.EnclosureUrl
+                        }} />
+                    )
+                })
+            }
+            {
+                loading && (
+                    <div className="flex justify-center py-6">
+                        <span className="loading loading-spinner loading-md"></span>
+                    </div>
+                )
+            }
+            <div ref={sentinelRef} className="h-4" />
+            {
+                !hasMore && items.length > 0 && (
+                    <div className="text-center text-neutral-500 text-sm py-6">No more episodes</div>
+                )
+            }
+        </div>
+    )
+}

--- a/app/subscription/[userId]/SubscriptionListClient.tsx
+++ b/app/subscription/[userId]/SubscriptionListClient.tsx
@@ -8,7 +8,9 @@ import UnsubscribeKeywordButton from "@/components/UnsubscribeKeywordButton"
 import { formatDateTime } from "@/libs/common"
 import { ServerUserInfo } from "@/libs/user"
 import { SubscriptionDataDto } from "@/types/subscription"
+import { FeedItem } from "@/types/feed_item"
 import Link from "next/link"
+import SubscriptionFeedList from "./SubscriptionFeedList"
 
 type Props = {
     userId: string
@@ -18,9 +20,11 @@ type Props = {
     subscriptionList: SubscriptionDataDto[]
     totalCount: number
     totalPage: number
+    initialFeedItems: FeedItem[]
+    feedTotalCount: number
 }
 
-export default function SubscriptionListClient({ userId, page, userInfo, nickname, subscriptionList, totalCount, totalPage }: Props) {
+export default function SubscriptionListClient({ userId, page, userInfo, nickname, subscriptionList, totalCount, totalPage, initialFeedItems, feedTotalCount }: Props) {
     const prevPage = page > 1 ? page - 1 : 1
     const nextPage = page < totalPage ? page + 1 : page
 
@@ -114,6 +118,11 @@ export default function SubscriptionListClient({ userId, page, userInfo, nicknam
                                     }
                                 </div>
                             </div>
+                            <SubscriptionFeedList
+                                userId={userId}
+                                initialItems={initialFeedItems}
+                                initialTotalCount={feedTotalCount}
+                            />
                         </div>
                     </div>
                 </Header>

--- a/app/subscription/[userId]/page.tsx
+++ b/app/subscription/[userId]/page.tsx
@@ -1,7 +1,8 @@
-import { getUserSubscriptionListServer } from "@/libs/subscription"
+import { getUserSubscriptionListServer, getUserAllSubscriptionItemsServer } from "@/libs/subscription"
 import { getUserInfoByIdServer, getTempNickname } from "@/libs/user"
 import { SubscriptionDataDto } from "@/types/subscription"
 import { ServerUserInfo } from "@/libs/user"
+import { FeedItem } from "@/types/feed_item"
 import SubscriptionListClient from "./SubscriptionListClient"
 
 type Props = {
@@ -18,6 +19,8 @@ export default async function Page({ params, searchParams }: Props) {
     let totalCount = 0
     let userInfo: ServerUserInfo | null = null
     let nickname = ""
+    let initialFeedItems: FeedItem[] = []
+    let feedTotalCount = 0
 
     const userResp = await getUserInfoByIdServer(userId)
     if (userResp.code === 0 && userResp.data) {
@@ -33,6 +36,12 @@ export default async function Page({ params, searchParams }: Props) {
         }
     }
 
+    const feedResp = await getUserAllSubscriptionItemsServer(userId, 0, 10)
+    if (feedResp.code === 0) {
+        initialFeedItems = feedResp.data
+        feedTotalCount = feedResp.totalCount
+    }
+
     const totalPage = Math.max(1, Math.ceil(totalCount / 10))
 
     return (
@@ -44,6 +53,8 @@ export default async function Page({ params, searchParams }: Props) {
             subscriptionList={subscriptionList}
             totalCount={totalCount}
             totalPage={totalPage}
+            initialFeedItems={initialFeedItems}
+            feedTotalCount={feedTotalCount}
         />
     )
 }

--- a/libs/db/subscription.ts
+++ b/libs/db/subscription.ts
@@ -332,3 +332,70 @@ export async function doSearchSubscription(keyword: string, country: string, sou
     }
 
 }
+
+export async function queryUserAllSubscriptionFeedItemList(userId: string, offset: number, limit: number): Promise<{ items: FeedItem[], totalCount: number }> {
+
+    const resultList: FeedItem[] = []
+
+    const queryResultList = await prisma.$queryRaw<FeedItemDto[]>(
+        Prisma.sql`
+        SELECT fi.*, ks.source, ks.exclude_feed_id, ks.country 
+        FROM feed_item fi 
+        INNER JOIN keyword_subscription ks ON (fi.id = ks.feed_item_id) 
+        INNER JOIN user_subscription usk ON (usk.keyword = ks.keyword AND usk.country = ks.country AND usk.exclude_feed_id = ks.exclude_feed_id AND usk.source = ks.source) 
+        WHERE usk.user_id = ${userId} AND usk.status = 1 
+        ORDER BY fi.pub_date DESC 
+        LIMIT ${limit}
+        OFFSET ${offset}
+        `
+    )
+
+    const countResult = await prisma.$queryRaw<{ count: bigint }[]>(
+        Prisma.sql`
+        SELECT COUNT(*) as count
+        FROM keyword_subscription ks
+        INNER JOIN user_subscription usk ON (usk.keyword = ks.keyword AND usk.country = ks.country AND usk.exclude_feed_id = ks.exclude_feed_id AND usk.source = ks.source)
+        WHERE usk.user_id = ${userId} AND usk.status = 1
+        `
+    )
+
+    const totalCount = Number(countResult[0]?.count || 0)
+
+    for (const queryResult of queryResultList) {
+        resultList.push({
+            Id: queryResult.id,
+            FeedId: queryResult.feed_id,
+            GUID: queryResult.guid || '',
+            ChannelId: queryResult.channel_id,
+            Title: queryResult.title || '',
+            HighlightTitle: queryResult.title || '',
+            Link: queryResult.link || '',
+            PubDate: formatDateTime(queryResult.pub_date?.toString() || new Date().toString()),
+            Author: queryResult.author || '',
+            InputDate: queryResult.input_date || new Date(),
+            ImageUrl: queryResult.image_url || '',
+            EnclosureUrl: queryResult.enclosure_url || '',
+            EnclosureLength: queryResult.enclosure_length || '0',
+            EnclosureType: queryResult.enclosure_type || '',
+            Description: String(queryResult.description) || '',
+            Source: queryResult.source || '',
+            Country: queryResult.country || '',
+            ExcludeFeedId: queryResult.exclude_feed_id || '',
+            Duration: queryResult.duration || '',
+            Episode: queryResult.episode || '',
+            Explicit: queryResult.explicit || '',
+            Season: queryResult.season || '',
+            EpisodeType: queryResult.enclosure_type || '',
+            TextDescription: '',
+            ChannelImageUrl: '',
+            ChannelTitle: queryResult.channel_title || '',
+            HighlightChannelTitle: "",
+            FeedLink: queryResult.feed_link || '',
+            Count: totalCount,
+            TookTime: 0,
+            HasThumbnail: true
+        })
+    }
+
+    return { items: resultList, totalCount }
+}

--- a/libs/subscription.ts
+++ b/libs/subscription.ts
@@ -1,7 +1,7 @@
 import { FeedItem } from "@/types/feed_item";
 import { getUserSessionInfo } from "./session";
 import { SubscriptionDataDto } from "@/types/subscription";
-import { queryUserKeywordSubscriptionList, queryUserKeywordSubscriptionDetail, queryKeywordSubscriptionFeedItemList } from "./db/subscription";
+import { queryUserKeywordSubscriptionList, queryUserKeywordSubscriptionDetail, queryKeywordSubscriptionFeedItemList, queryUserAllSubscriptionFeedItemList } from "./db/subscription";
 
 // ─── Client-side (keep for interactive operations) ───
 
@@ -100,6 +100,22 @@ export const unsubscribeKeyword = async (userId: string, keyword: string): Promi
     return respJson
 }
 
+export const getUserAllSubscriptionItems = async (userId: string, offset: number, limit: number): Promise<{ code: number, message: string, data: FeedItem[] }> => {
+    const resp = await fetch(`${process.env.API_BASE_URL}api/subscription/items?userId=${userId}&offset=${offset}&limit=${limit}`, {
+        method: 'GET',
+        headers: {
+            'Content-Type': 'application/json',
+        }
+    })
+    const respJson = await resp.json()
+
+    return {
+        code: respJson.code,
+        message: respJson.message,
+        data: respJson.data
+    }
+}
+
 // ─── Server-side (direct Prisma, no network hop) ───
 
 export async function getUserSubscriptionListServer(userId: string): Promise<{ code: number, message: string, data: SubscriptionDataDto[] }> {
@@ -122,6 +138,16 @@ export async function getUserKeywordSubscriptionItemListServer(userId: string, k
     } catch (err) {
         console.error('getUserKeywordSubscriptionItemListServer error:', err)
         return { code: 1, message: String(err), data: [] }
+    }
+}
+
+export async function getUserAllSubscriptionItemsServer(userId: string, offset: number, limit: number): Promise<{ code: number, message: string, data: FeedItem[], totalCount: number }> {
+    try {
+        const { items, totalCount } = await queryUserAllSubscriptionFeedItemList(userId, offset, limit)
+        return { code: 0, message: 'ok', data: items, totalCount }
+    } catch (err) {
+        console.error('getUserAllSubscriptionItemsServer error:', err)
+        return { code: 1, message: String(err), data: [], totalCount: 0 }
     }
 }
 


### PR DESCRIPTION
## Summary

- Added `queryUserAllSubscriptionFeedItemList` DB function that joins across all user keyword subscriptions to fetch feed items ordered by publish date
- Created `GET /api/subscription/items` endpoint for paginated (offset/limit) feed item queries
- Added `SubscriptionFeedList` client component with IntersectionObserver-based infinite scroll (loads 10 items per scroll)
- Server-renders initial 10 items, client fetches subsequent pages on scroll
- Renders the aggregated episode feed list below the existing keyword subscription cards on `/subscription/[userId]`

## Files changed

| File | Change |
|---|---|
| `libs/db/subscription.ts` | Added `queryUserAllSubscriptionFeedItemList` |
| `libs/subscription.ts` | Added client-side and server-side fetch functions |
| `app/api/subscription/items/route.ts` | New API endpoint |
| `app/subscription/[userId]/SubscriptionFeedList.tsx` | New infinite-scroll component |
| `app/subscription/[userId]/page.tsx` | Fetch initial feed items server-side |
| `app/subscription/[userId]/SubscriptionListClient.tsx` | Render feed items section below keyword list |