### PR TITLE
fix: change subscription item list ordering from input_date to pub_date

### DIFF
--- a/libs/db/subscription.ts
+++ b/libs/db/subscription.ts
@@ -99,7 +99,7 @@ export async function queryKeywordSubscriptionFeedItemList(userId: string, keywo
         INNER JOIN keyword_subscription ks ON (fi.id = ks.feed_item_id) 
         INNER JOIN user_subscription usk ON (usk.keyword = ks.keyword and usk.country = ks.country and usk.exclude_feed_id = ks.exclude_feed_id and usk.source = ks.source) 
         WHERE usk.user_id = ${userId} and usk.keyword = ${keyword} and usk.source = ${source} and usk.country = ${country} and usk.exclude_feed_id = ${excludeFeedId} and usk.status = 1 
-        ORDER BY fi.input_date DESC 
+        ORDER BY fi.pub_date DESC 
         LIMIT ${limit}
         OFFSET ${offset}
         `
@@ -165,7 +165,7 @@ export async function queryUserLatestKeywordSubscriptionFeedItemList(userId: str
         INNER JOIN keyword_subscription ks ON (fi.id = ks.feed_item_id) 
         INNER JOIN user_subscription usk ON (usk.keyword = ks.keyword and usk.country = ks.country and usk.exclude_feed_id = ks.exclude_feed_id and usk.source = ks.source) 
         WHERE usk.user_id = ${userId} and usk.keyword = ${keyword} and usk.source = ${source} and usk.country = ${country} and usk.exclude_feed_id = ${excludeFeedId} and ks.id > ${latestId} and usk.status = 1 
-        ORDER BY fi.input_date DESC 
+        ORDER BY fi.pub_date DESC 
         LIMIT ${limit}
         OFFSET ${offset}
         `


### PR DESCRIPTION
## Summary

Changed `ORDER BY` from `fi.input_date` to `fi.pub_date` in two subscription query functions so all subscription-related episode lists show episodes ordered by their actual publish date instead of the date they were ingested.

## Affected

- `queryKeywordSubscriptionFeedItemList` — keyword detail page, share page, server-side fetch
- `queryUserLatestKeywordSubscriptionFeedItemList` — notification email job

`queryUserAllSubscriptionFeedItemList` already used `fi.pub_date` — no change needed.