### PR TITLE
fix: add initials avatar fallback when user avatar is empty

### DIFF
--- a/app/listenlater/[userId]/ListenLaterClient.tsx
+++ b/app/listenlater/[userId]/ListenLaterClient.tsx
@@ -47,7 +47,7 @@ export default function ListenLaterClient({ userId, page, userInfo, nickname, it
                             <div className="w-full flex justify-center mb-10">
                                 <div className="mt-4">
                                     <div className="flex justify-center">
-                                        <AvatarImage className="w-28" imageUrl={userInfo?.avatar} />
+                                        <AvatarImage className="w-28" imageUrl={userInfo?.avatar} displayName={nickname} />
                                     </div>
                                     <div className="mt-4 flex justify-center">
                                         <div className="md:text-2xl text-xl font-bold">{nickname}{`'s Porkast Listen Later`}</div>

--- a/app/playlist/[userId]/PlaylistListClient.tsx
+++ b/app/playlist/[userId]/PlaylistListClient.tsx
@@ -35,7 +35,7 @@ export default function PlaylistListClient({ userId, page, userInfo, nickname, p
                                 <div className="flex justify-center mt-4">
                                     <div className="w-full">
                                         <div className="flex justify-center">
-                                            <AvatarImage className="w-28" imageUrl={userInfo?.avatar} />
+                                            <AvatarImage className="w-28" imageUrl={userInfo?.avatar} displayName={nickname} />
                                         </div>
                                         <div className="flex justify-center mt-4">
                                             <div className="md:text-2xl text-xl font-bold">{nickname}{`'s Porkast Playlist`}</div>

--- a/app/playlist/[userId]/[playlistId]/PlaylistDetailClient.tsx
+++ b/app/playlist/[userId]/[playlistId]/PlaylistDetailClient.tsx
@@ -49,7 +49,7 @@ export default function PlaylistDetailClient({ userId, playlistId, page, userInf
                             <div className='w-full max-w-2xl pl-6 pr-6'>
                                 <div className="w-full mb-10">
                                     <div className="flex justify-start mt-4">
-                                        <AvatarImage className="w-28" imageUrl={userInfo?.avatar} />
+                                        <AvatarImage className="w-28" imageUrl={userInfo?.avatar} displayName={nickname} />
                                         <div className="ml-3">
                                             <div className="md:text-2xl text-xl font-bold">{playlistInfo?.PlaylistName}</div>
                                             <div className="text-sm font-medium text-gray-500 mt-2">By {nickname}</div>

--- a/app/subscription/[userId]/SubscriptionListClient.tsx
+++ b/app/subscription/[userId]/SubscriptionListClient.tsx
@@ -38,7 +38,7 @@ export default function SubscriptionListClient({ userId, page, userInfo, nicknam
                                 <div className="flex justify-center mt-4">
                                     <div className="w-full">
                                         <div className="flex justify-center">
-                                            <AvatarImage className="w-28" imageUrl={userInfo?.avatar} />
+                                            <AvatarImage className="w-28" imageUrl={userInfo?.avatar} displayName={nickname} />
                                         </div>
                                         <div className="flex justify-center mt-4">
                                             <div className="md:text-2xl text-xl font-bold">{nickname}{`'s Subscription`}</div>

--- a/app/subscription/[userId]/[keyword]/SubscriptionKeywordClient.tsx
+++ b/app/subscription/[userId]/[keyword]/SubscriptionKeywordClient.tsx
@@ -49,7 +49,7 @@ export default function SubscriptionKeywordClient({ userId, keyword, decodedKeyw
                         <div className='w-full max-w-2xl pl-6 pr-6'>
                             <div className="w-full mb-10">
                                 <div className="flex justify-start mt-4">
-                                    <AvatarImage className="w-28" imageUrl={userInfo?.avatar} />
+                                    <AvatarImage className="w-28" imageUrl={userInfo?.avatar} displayName={nickname} />
                                     <div className="ml-3">
                                         <div className="md:text-2xl text-xl font-bold">#{decodedKeyword}</div>
                                         <div className="text-sm font-medium text-gray-500 mt-2">Search keyword #{decodedKeyword} subscription</div>

--- a/components/PorkastImage.tsx
+++ b/components/PorkastImage.tsx
@@ -1,20 +1,37 @@
 'use client'
 import { useEffect, useState } from "react"
 
+const AVATAR_COLORS = [
+    '#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7',
+    '#DDA0DD', '#98D8C8', '#F7DC6F', '#BB8FCE', '#85C1E9',
+    '#F8C471', '#82E0AA', '#E74C3C', '#3498DB', '#2ECC71',
+    '#9B59B6', '#1ABC9C', '#E67E22', '#F1C40F', '#34495E'
+]
+
+function getColorFromName(name: string): string {
+    let hash = 0
+    for (let i = 0; i < name.length; i++) {
+        hash = name.charCodeAt(i) + ((hash << 5) - hash)
+    }
+    return AVATAR_COLORS[Math.abs(hash) % AVATAR_COLORS.length]
+}
+
+function getInitial(name: string): string {
+    return name.charAt(0).toUpperCase()
+}
 
 type AvatarImageProps = {
     imageUrl?: string
     className?: string
+    displayName?: string
 }
 
-export const AvatarImage = ({ imageUrl, className }: AvatarImageProps) => {
+export const AvatarImage = ({ imageUrl, className, displayName }: AvatarImageProps) => {
 
     const [avatarUrl, setAvatarUrl] = useState("")
 
     useEffect(() => {
-        if (imageUrl) {
-            setAvatarUrl(imageUrl)
-        }
+        setAvatarUrl(imageUrl || "")
     }, [imageUrl])
 
     return (
@@ -24,7 +41,27 @@ export const AvatarImage = ({ imageUrl, className }: AvatarImageProps) => {
                     {
                         avatarUrl ?
                             <img src={avatarUrl} />
-                            :
+                        : displayName ?
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                viewBox="0 0 100 100"
+                                className="w-full h-full"
+                            >
+                                <circle cx="50" cy="50" r="50" fill={getColorFromName(displayName)} />
+                                <text
+                                    x="50"
+                                    y="50"
+                                    textAnchor="middle"
+                                    dominantBaseline="central"
+                                    fill="white"
+                                    fontSize="40"
+                                    fontWeight="bold"
+                                    fontFamily="system-ui, -apple-system, sans-serif"
+                                >
+                                    {getInitial(displayName)}
+                                </text>
+                            </svg>
+                        :
                             <img src="/porkast-text-logo.png" />
                     }
                 </div>


### PR DESCRIPTION
## Summary

- Added `displayName` prop to `AvatarImage` component
- When user has no avatar image, render an inline SVG initials avatar (colored circle + first letter of displayName) instead of the static Porkast logo
- Color is deterministically generated from the displayName hash, so the same user always gets the same color

## Changes

- `components/PorkastImage.tsx` — added `displayName` prop, SVG initials fallback with 20-color palette
- 5 page components — passed `displayName={nickname}` to `AvatarImage`

## Why

After switching from Google login to email+OTP, new users have no avatar URL. Previously all users without avatar saw the same Porkast logo — now each user gets a distinct, personalized initials avatar as a fallback.