### PR TITLE
feat: enforce keyword subscription limits based on membership tier

### DIFF
--- a/app/api/subscription/keyword/route.ts
+++ b/app/api/subscription/keyword/route.ts
@@ -1,3 +1,4 @@
+import { checkKeywordLimit } from "@/libs/membership";
 import { doSearchSubscription } from "@/libs/db/subscription";
 import prisma from "@/libs/prisma";
 import { JsonResponse } from "@/types/api";
@@ -41,16 +42,11 @@ export async function POST(request: NextRequest) {
         return NextResponse.json(resp);
     }
 
-    const subscribedCount = await prisma.user_subscription.count({
-        where: {
-            user_id: userId,
-            status: 1
-        }
-    })
+    const { allowed, limit, used } = await checkKeywordLimit(userId)
 
-    if (subscribedCount >= 5) {
+    if (!allowed) {
         resp.code = 1
-        resp.message = 'Subscription limit reached'
+        resp.message = `You have reached the limit of search keyword subscriptions. Please download the iOS client and subscribe to a membership plan to increase the limit.`
         return NextResponse.json(resp);
     }
 

--- a/app/subscription/[userId]/SubscriptionListClient.tsx
+++ b/app/subscription/[userId]/SubscriptionListClient.tsx
@@ -22,9 +22,20 @@ type Props = {
     totalPage: number
     initialFeedItems: FeedItem[]
     feedTotalCount: number
+    keywordsUsed: number
+    keywordsLimit: number | null
+    tier: string
 }
 
-export default function SubscriptionListClient({ userId, page, userInfo, nickname, subscriptionList, totalCount, totalPage, initialFeedItems, feedTotalCount }: Props) {
+function formatTier(tier: string): string {
+    switch (tier) {
+        case 'unlimited': return 'Unlimited'
+        case 'pro': return 'Pro'
+        default: return 'Free'
+    }
+}
+
+export default function SubscriptionListClient({ userId, page, userInfo, nickname, subscriptionList, totalCount, totalPage, initialFeedItems, feedTotalCount, keywordsUsed, keywordsLimit, tier }: Props) {
     const prevPage = page > 1 ? page - 1 : 1
     const nextPage = page < totalPage ? page + 1 : page
 
@@ -46,6 +57,16 @@ export default function SubscriptionListClient({ userId, page, userInfo, nicknam
                                         <div className="flex justify-center mt-4">
                                             <div className="mt-4 text-sm text-gray-500">{nickname}@Porkast</div>
                                         </div>
+                                    </div>
+                                </div>
+                                <div className="flex justify-center mt-3">
+                                    <div className="badge badge-primary badge-lg gap-1">
+                                        <span className="font-semibold">{formatTier(tier)}</span>
+                                        <span className="opacity-50">·</span>
+                                        <span>Keywords:</span>
+                                        <span className="font-semibold">{keywordsUsed}</span>
+                                        <span>/</span>
+                                        <span className="font-semibold">{keywordsLimit === null ? '∞' : keywordsLimit}</span>
                                     </div>
                                 </div>
                             </div>

--- a/app/subscription/[userId]/page.tsx
+++ b/app/subscription/[userId]/page.tsx
@@ -1,3 +1,4 @@
+import { getUserMembershipStatus } from "@/libs/membership"
 import { getUserSubscriptionListServer, getUserAllSubscriptionItemsServer } from "@/libs/subscription"
 import { getUserInfoByIdServer, getTempNickname } from "@/libs/user"
 import { SubscriptionDataDto } from "@/types/subscription"
@@ -42,6 +43,11 @@ export default async function Page({ params, searchParams }: Props) {
         feedTotalCount = feedResp.totalCount
     }
 
+    const membershipStatus = await getUserMembershipStatus(userId)
+    const keywordsUsed = membershipStatus.keywordsUsed
+    const keywordsLimit = membershipStatus.keywordsLimit
+    const tier = membershipStatus.tier
+
     const totalPage = Math.max(1, Math.ceil(totalCount / 10))
 
     return (
@@ -55,6 +61,9 @@ export default async function Page({ params, searchParams }: Props) {
             totalPage={totalPage}
             initialFeedItems={initialFeedItems}
             feedTotalCount={feedTotalCount}
+            keywordsUsed={keywordsUsed}
+            keywordsLimit={keywordsLimit}
+            tier={tier}
         />
     )
 }

--- a/libs/membership.ts
+++ b/libs/membership.ts
@@ -1,0 +1,69 @@
+import prisma from "./prisma"
+
+const TIER_KEYWORDS_LIMIT: Record<string, number | null> = {
+  free: 5,
+  pro: 20,
+  unlimited: null,
+}
+
+export interface MembershipStatusResult {
+  tier: string
+  productId: string | null
+  expiresDate: string | null
+  isActive: boolean
+  willRenew: boolean
+  keywordsLimit: number | null
+  keywordsUsed: number
+}
+
+export async function getUserMembershipStatus(
+  userId: string
+): Promise<MembershipStatusResult> {
+  const membership = await prisma.user_membership.findFirst({
+    where: {
+      user_id: userId,
+      is_active: true,
+      expires_date: { gt: new Date() },
+    },
+    orderBy: { expires_date: "desc" },
+  })
+
+  const keywordsUsed = await prisma.user_subscription.count({
+    where: { user_id: userId, status: 1 },
+  })
+
+  if (membership) {
+    const tier = membership.tier
+    return {
+      tier,
+      productId: membership.product_id,
+      expiresDate: membership.expires_date?.toISOString() ?? null,
+      isActive: true,
+      willRenew: membership.will_renew,
+      keywordsLimit: TIER_KEYWORDS_LIMIT[tier] ?? null,
+      keywordsUsed,
+    }
+  }
+
+  return {
+    tier: "free",
+    productId: null,
+    expiresDate: null,
+    isActive: false,
+    willRenew: false,
+    keywordsLimit: TIER_KEYWORDS_LIMIT["free"],
+    keywordsUsed,
+  }
+}
+
+export async function checkKeywordLimit(
+  userId: string
+): Promise<{ allowed: boolean; limit: number | null; used: number }> {
+  const status = await getUserMembershipStatus(userId)
+  const limit = status.keywordsLimit
+  const used = status.keywordsUsed
+  if (limit === null) {
+    return { allowed: true, limit: null, used }
+  }
+  return { allowed: used < limit, limit, used }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -193,6 +193,25 @@ model user_subscription {
   @@schema("public")
 }
 
+model user_membership {
+  id                      String    @id @db.VarChar(64)
+  user_id                 String    @db.VarChar(64)
+  product_id              String    @db.VarChar(128)
+  tier                    String    @db.VarChar(32)
+  original_transaction_id String    @unique @db.VarChar(128)
+  latest_transaction_id   String?   @db.VarChar(128)
+  expires_date            DateTime? @db.Timestamp(6)
+  is_active               Boolean   @default(false)
+  will_renew              Boolean   @default(true)
+  is_in_billing_retry     Boolean   @default(false)
+  environment             String    @default("Production") @db.VarChar(16)
+  created_at              DateTime  @default(now()) @db.Timestamp(6)
+  updated_at              DateTime  @updatedAt @db.Timestamp(6)
+
+  @@index([user_id])
+  @@schema("public")
+}
+
 model verification_token {
   id         String   @id @default(cuid()) @db.VarChar(64)
   email      String   @db.VarChar(128)


### PR DESCRIPTION
## Summary

- Added `user_membership` model to Prisma schema (table already exists in the shared database, created by porkast-svc)
- Created `libs/membership.ts` with tier-based keyword limit logic (`free: 5`, `pro: 20`, `unlimited: no limit`)
- Updated `POST /api/subscription/keyword` to enforce membership-based limits instead of hardcoded 5
- Added membership tier & keyword usage display (`Tier · Keywords: used/limit`) to the subscription page
- Replaced `badge-outline` with `badge-primary` for better visual integration

When users reach the limit, the API returns a message directing them to download the iOS client to subscribe to a membership plan.